### PR TITLE
Apply BooleanSupplier to timer tasks

### DIFF
--- a/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
+++ b/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 
 @SuppressWarnings("unused")
 public interface ServerImplementation {
@@ -83,12 +84,40 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     * @param runnable Task to run, return false to stop the timer
+     * @param delay Delay before first execution in ticks
+     * @param period Delay between executions in ticks
+     * @return WrappedTask instance
+     */
+    WrappedTask runTimer(BooleanSupplier runnable, long delay, long period);
+
+    /**
+     * Folia: Synced with the server daylight cycle tick
+     * Paper: Synced with the server main thread
+     * Spigot: Synced with the server main thread
      * @param runnable Task to run
      * @param delay Delay before first execution in ticks
      * @param period Delay between executions in ticks
      * @return WrappedTask instance
      */
-    WrappedTask runTimer(Runnable runnable, long delay, long period);
+    default WrappedTask runTimer(Runnable runnable, long delay, long period) {
+        return runTimer(() -> {
+            runnable.run();
+            return true;
+        }, delay, period);
+    }
+
+    /**
+     * Folia: Synced with the server daylight cycle tick
+     * Paper: Synced with the server main thread
+     * Spigot: Synced with the server main thread
+     * @param runnable Task to run, return false to stop the timer
+     * @param delay Delay before first execution
+     * @param period Delay between executions
+     * @param unit Time unit
+     * @return WrappedTask instance
+     */
+    WrappedTask runTimer(BooleanSupplier runnable, long delay, long period, TimeUnit unit);
 
     /**
      * Folia: Synced with the server daylight cycle tick
@@ -100,7 +129,23 @@ public interface ServerImplementation {
      * @param unit Time unit
      * @return WrappedTask instance
      */
-    WrappedTask runTimer(Runnable runnable, long delay, long period, TimeUnit unit);
+    default WrappedTask runTimer(Runnable runnable, long delay, long period, TimeUnit unit) {
+        return runTimer(() -> {
+            runnable.run();
+            return true;
+        }, delay, period, unit);
+    }
+
+    /**
+     * Folia: Async
+     * Paper: Async
+     * Spigot: Async
+     * @param runnable Task to run, return false to stop the timer
+     * @param delay Delay before first execution in ticks
+     * @param period Delay between executions in ticks
+     * @return WrappedTask instance
+     */
+    WrappedTask runTimerAsync(BooleanSupplier runnable, long delay, long period);
 
     /**
      * Folia: Async
@@ -111,19 +156,41 @@ public interface ServerImplementation {
      * @param period Delay between executions in ticks
      * @return WrappedTask instance
      */
-    WrappedTask runTimerAsync(Runnable runnable, long delay, long period);
+    default WrappedTask runTimerAsync(Runnable runnable, long delay, long period) {
+        return runTimerAsync(() -> {
+            runnable.run();
+            return true;
+        }, delay, period);
+    }
 
     /**
      * Folia: Async
      * Paper: Async
      * Spigot: Async
-     * @param runnable Task to run
+     * @param runnable Task to run, return false to stop the timer
      * @param delay Delay before first execution
      * @param period Delay between executions
      * @param unit Time unit
      * @return WrappedTask instance
      */
-    WrappedTask runTimerAsync(Runnable runnable, long delay, long period, TimeUnit unit);
+    WrappedTask runTimerAsync(BooleanSupplier runnable, long delay, long period, TimeUnit unit);
+
+    /**
+     * Folia: Async
+     * Paper: Async
+     * Spigot: Async
+     * @param runnable Task to run, return false to stop the timer
+     * @param delay Delay before first execution
+     * @param period Delay between executions
+     * @param unit Time unit
+     * @return WrappedTask instance
+     */
+    default WrappedTask runTimerAsync(Runnable runnable, long delay, long period, TimeUnit unit) {
+        return runTimerAsync(() -> {
+            runnable.run();
+            return true;
+        }, delay, period, unit);
+    }
 
 
     // ----- Location/Region based -----
@@ -166,12 +233,42 @@ public interface ServerImplementation {
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
      * @param location Location to run the task at
-     * @param runnable Task to run
+     * @param runnable Task to run, return false to stop the timer
      * @param delay Delay before first execution in ticks
      * @param period Delay between executions in ticks
      * @return WrappedTask instance
      */
-    WrappedTask runAtLocationTimer(Location location, Runnable runnable, long delay, long period);
+    WrappedTask runAtLocationTimer(Location location, BooleanSupplier runnable, long delay, long period);
+
+    /**
+     * Folia: Synced with the tick of the region of the chunk of the location
+     * Paper: Synced with the server main thread
+     * Spigot: Synced with the server main thread
+     * @param location Location to run the task at
+     * @param runnable Task to run
+     * @param delay Delay before first execution
+     * @param period Delay between executions
+     * @return WrappedTask instance
+     */
+    default WrappedTask runAtLocationTimer(Location location, Runnable runnable, long delay, long period) {
+        return runAtLocationTimer(location, () -> {
+            runnable.run();
+            return true;
+        }, delay, period);
+    }
+
+    /**
+     * Folia: Synced with the tick of the region of the chunk of the location
+     * Paper: Synced with the server main thread
+     * Spigot: Synced with the server main thread
+     * @param location Location to run the task at
+     * @param runnable Task to run, return false to stop the timer
+     * @param delay Delay before first execution
+     * @param period Delay between executions
+     * @param unit Time unit
+     * @return WrappedTask instance
+     */
+    WrappedTask runAtLocationTimer(Location location, BooleanSupplier runnable, long delay, long period, TimeUnit unit);
 
     /**
      * Folia: Synced with the tick of the region of the chunk of the location
@@ -184,7 +281,12 @@ public interface ServerImplementation {
      * @param unit Time unit
      * @return WrappedTask instance
      */
-    WrappedTask runAtLocationTimer(Location location, Runnable runnable, long delay, long period, TimeUnit unit);
+    default WrappedTask runAtLocationTimer(Location location, Runnable runnable, long delay, long period, TimeUnit unit) {
+        return runAtLocationTimer(location, () -> {
+            runnable.run();
+            return true;
+        }, delay, period, unit);
+    }
 
 
     // ----- Entity based -----
@@ -237,12 +339,42 @@ public interface ServerImplementation {
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
      * @param entity Entity to run the task at
-     * @param runnable Task to run
+     * @param runnable Task to run, return false to stop the timer
      * @param delay Delay before first execution in ticks
      * @param period Delay between executions in ticks
      * @return WrappedTask instance
      */
-    WrappedTask runAtEntityTimer(Entity entity, Runnable runnable, long delay, long period);
+    WrappedTask runAtEntityTimer(Entity entity, BooleanSupplier runnable, long delay, long period);
+
+    /**
+     * Folia: Synced with the tick of the region of the entity (even if the entity moves)
+     * Paper: Synced with the server main thread
+     * Spigot: Synced with the server main thread
+     * @param entity Entity to run the task at
+     * @param runnable Task to run
+     * @param delay Delay before first execution
+     * @param period Delay between executions
+     * @return WrappedTask instance
+     */
+    default WrappedTask runAtEntityTimer(Entity entity, Runnable runnable, long delay, long period) {
+        return runAtEntityTimer(entity, () -> {
+            runnable.run();
+            return true;
+        }, delay, period);
+    }
+
+    /**
+     * Folia: Synced with the tick of the region of the entity (even if the entity moves)
+     * Paper: Synced with the server main thread
+     * Spigot: Synced with the server main thread
+     * @param entity Entity to run the task at
+     * @param runnable Task to run, return false to stop the timer
+     * @param delay Delay before first execution
+     * @param period Delay between executions
+     * @param unit Time unit
+     * @return WrappedTask instance
+     */
+    WrappedTask runAtEntityTimer(Entity entity, BooleanSupplier runnable, long delay, long period, TimeUnit unit);
 
     /**
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
@@ -255,7 +387,12 @@ public interface ServerImplementation {
      * @param unit Time unit
      * @return WrappedTask instance
      */
-    WrappedTask runAtEntityTimer(Entity entity, Runnable runnable, long delay, long period, TimeUnit unit);
+    default WrappedTask runAtEntityTimer(Entity entity, Runnable runnable, long delay, long period, TimeUnit unit) {
+        return runAtEntityTimer(entity, () -> {
+            runnable.run();
+            return true;
+        }, delay, period, unit);
+    }
 
     /**
      * Cancel a task

--- a/platform/spigot/src/main/java/com/tcoded/folialib/impl/SpigotImplementation.java
+++ b/platform/spigot/src/main/java/com/tcoded/folialib/impl/SpigotImplementation.java
@@ -9,6 +9,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.jetbrains.annotations.NotNull;
 
@@ -16,6 +17,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
 @SuppressWarnings("unused")
@@ -27,6 +29,17 @@ public class SpigotImplementation implements ServerImplementation {
     public SpigotImplementation(FoliaLib foliaLib) {
         this.plugin = foliaLib.getPlugin();
         this.scheduler = plugin.getServer().getScheduler();
+    }
+
+    private static BukkitRunnable wrapRunnable(BooleanSupplier runnable) {
+        return new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!runnable.getAsBoolean()) {
+                    this.cancel();
+                }
+            }
+        };
     }
 
     @Override
@@ -74,22 +87,22 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public WrappedTask runTimer(Runnable runnable, long delay, long period) {
-        return new WrappedBukkitTask(this.scheduler.runTaskTimer(plugin, runnable, delay, period));
+    public WrappedTask runTimer(BooleanSupplier runnable, long delay, long period) {
+        return new WrappedBukkitTask(wrapRunnable(runnable).runTaskTimer(plugin, delay, period));
     }
 
     @Override
-    public WrappedTask runTimer(Runnable runnable, long delay, long period, TimeUnit unit) {
+    public WrappedTask runTimer(BooleanSupplier runnable, long delay, long period, TimeUnit unit) {
         return this.runTimer(runnable, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
     @Override
-    public WrappedTask runTimerAsync(Runnable runnable, long delay, long period) {
-        return new WrappedBukkitTask(this.scheduler.runTaskTimerAsynchronously(plugin, runnable, delay, period));
+    public WrappedTask runTimerAsync(BooleanSupplier runnable, long delay, long period) {
+        return new WrappedBukkitTask(wrapRunnable(runnable).runTaskTimerAsynchronously(plugin, delay, period));
     }
 
     @Override
-    public WrappedTask runTimerAsync(Runnable runnable, long delay, long period, TimeUnit unit) {
+    public WrappedTask runTimerAsync(BooleanSupplier runnable, long delay, long period, TimeUnit unit) {
         return this.runTimerAsync(runnable, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
@@ -116,12 +129,12 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public WrappedTask runAtLocationTimer(Location location, Runnable runnable, long delay, long period) {
-        return new WrappedBukkitTask(this.scheduler.runTaskTimer(plugin, runnable, delay, period));
+    public WrappedTask runAtLocationTimer(Location location, BooleanSupplier runnable, long delay, long period) {
+        return new WrappedBukkitTask(wrapRunnable(runnable).runTaskTimer(plugin, delay, period));
     }
 
     @Override
-    public WrappedTask runAtLocationTimer(Location location, Runnable runnable, long delay, long period, TimeUnit unit) {
+    public WrappedTask runAtLocationTimer(Location location, BooleanSupplier runnable, long delay, long period, TimeUnit unit) {
         return this.runAtLocationTimer(location, runnable, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
@@ -165,12 +178,12 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public WrappedTask runAtEntityTimer(Entity entity, Runnable runnable, long delay, long period) {
-        return new WrappedBukkitTask(this.scheduler.runTaskTimer(plugin, runnable, delay, period));
+    public WrappedTask runAtEntityTimer(Entity entity, BooleanSupplier runnable, long delay, long period) {
+        return new WrappedBukkitTask(wrapRunnable(runnable).runTaskTimer(plugin, delay, period));
     }
 
     @Override
-    public WrappedTask runAtEntityTimer(Entity entity, Runnable runnable, long delay, long period, TimeUnit unit) {
+    public WrappedTask runAtEntityTimer(Entity entity, BooleanSupplier runnable, long delay, long period, TimeUnit unit) {
         return this.runAtEntityTimer(entity, runnable, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 


### PR DESCRIPTION
This tries to mimic the `cancel()` method inside `BukkitRunnable`, in the case that the runnable can itself be cancelled.

This uses `BooleanSupplier`, so that we can cancel a timer task by returning `false` on the getAsBoolean method.

Draft example:
```java
int i = 0;

public boolean getAsBoolean() {
  if (i < 60) {
    i++;
    return true; // continue the task on the next tick
  } else {
    return false; // cancel the task
  }
}
```