### PR TITLE
Support TeleportCause for function "teleportAsync"

### DIFF
--- a/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
+++ b/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
@@ -21,7 +21,6 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param consumer Task to run
      * @return Future when the task is completed
      */
@@ -31,7 +30,6 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
-     *
      * @param consumer Task to run
      * @return Future when the task is completed
      */
@@ -43,9 +41,8 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param runnable Task to run
-     * @param delay    Delay before execution in ticks
+     * @param delay Delay before execution in ticks
      * @return WrappedTask instance
      */
     WrappedTask runLater(Runnable runnable, long delay);
@@ -54,9 +51,8 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param consumer Task to run
-     * @param delay    Delay before execution in ticks
+     * @param delay Delay before execution in ticks
      */
     void runLater(Consumer<WrappedTask> consumer, long delay);
 
@@ -64,10 +60,9 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param runnable Task to run
-     * @param delay    Delay before execution
-     * @param unit     Time unit
+     * @param delay Delay before execution
+     * @param unit Time unit
      * @return WrappedTask instance
      */
     WrappedTask runLater(Runnable runnable, long delay, TimeUnit unit);
@@ -76,10 +71,9 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param consumer Task to run
-     * @param delay    Delay before execution
-     * @param unit     Time unit
+     * @param delay Delay before execution
+     * @param unit Time unit
      */
     void runLater(Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
@@ -87,9 +81,8 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
-     *
      * @param runnable Task to run
-     * @param delay    Delay before execution in ticks
+     * @param delay Delay before execution in ticks
      * @return WrappedTask instance
      */
     WrappedTask runLaterAsync(Runnable runnable, long delay);
@@ -98,9 +91,8 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
-     *
      * @param consumer Task to run
-     * @param delay    Delay before execution in ticks
+     * @param delay Delay before execution in ticks
      */
     void runLaterAsync(Consumer<WrappedTask> consumer, long delay);
 
@@ -108,10 +100,9 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
-     *
      * @param runnable Task to run
-     * @param delay    Delay before execution
-     * @param unit     Time unit
+     * @param delay Delay before execution
+     * @param unit Time unit
      * @return WrappedTask instance
      */
     WrappedTask runLaterAsync(Runnable runnable, long delay, TimeUnit unit);
@@ -120,10 +111,9 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
-     *
      * @param consumer Task to run
-     * @param delay    Delay before execution
-     * @param unit     Time unit
+     * @param delay Delay before execution
+     * @param unit Time unit
      */
     void runLaterAsync(Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
@@ -133,10 +123,9 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param runnable Task to run
-     * @param delay    Delay before first execution in ticks
-     * @param period   Delay between executions in ticks
+     * @param delay Delay before first execution in ticks
+     * @param period Delay between executions in ticks
      * @return WrappedTask instance
      */
     WrappedTask runTimer(Runnable runnable, long delay, long period);
@@ -145,10 +134,9 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param consumer Task to run
-     * @param delay    Delay before first execution in ticks
-     * @param period   Delay between executions in ticks
+     * @param delay Delay before first execution in ticks
+     * @param period Delay between executions in ticks
      */
     void runTimer(Consumer<WrappedTask> consumer, long delay, long period);
 
@@ -156,11 +144,10 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param runnable Task to run
-     * @param delay    Delay before first execution
-     * @param period   Delay between executions
-     * @param unit     Time unit
+     * @param delay Delay before first execution
+     * @param period Delay between executions
+     * @param unit Time unit
      * @return WrappedTask instance
      */
     WrappedTask runTimer(Runnable runnable, long delay, long period, TimeUnit unit);
@@ -169,11 +156,10 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param consumer Task to run
-     * @param delay    Delay before first execution
-     * @param period   Delay between executions
-     * @param unit     Time unit
+     * @param delay Delay before first execution
+     * @param period Delay between executions
+     * @param unit Time unit
      */
     void runTimer(Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit);
 
@@ -181,10 +167,9 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
-     *
      * @param runnable Task to run
-     * @param delay    Delay before first execution in ticks
-     * @param period   Delay between executions in ticks
+     * @param delay Delay before first execution in ticks
+     * @param period Delay between executions in ticks
      * @return WrappedTask instance
      */
     WrappedTask runTimerAsync(Runnable runnable, long delay, long period);
@@ -193,10 +178,9 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
-     *
      * @param consumer Task to run
-     * @param delay    Delay before first execution in ticks
-     * @param period   Delay between executions in ticks
+     * @param delay Delay before first execution in ticks
+     * @param period Delay between executions in ticks
      */
     void runTimerAsync(Consumer<WrappedTask> consumer, long delay, long period);
 
@@ -204,11 +188,10 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
-     *
      * @param runnable Task to run
-     * @param delay    Delay before first execution
-     * @param period   Delay between executions
-     * @param unit     Time unit
+     * @param delay Delay before first execution
+     * @param period Delay between executions
+     * @param unit Time unit
      * @return WrappedTask instance
      */
     WrappedTask runTimerAsync(Runnable runnable, long delay, long period, TimeUnit unit);
@@ -217,11 +200,10 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
-     *
      * @param consumer Task to run
-     * @param delay    Delay before first execution
-     * @param period   Delay between executions
-     * @param unit     Time unit
+     * @param delay Delay before first execution
+     * @param period Delay between executions
+     * @param unit Time unit
      */
     void runTimerAsync(Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit);
 
@@ -232,7 +214,6 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param location Location to run the task at
      * @param consumer Task to run
      * @return Future when the task is completed
@@ -243,10 +224,9 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param location Location to run the task at
      * @param runnable Task to run
-     * @param delay    Delay before execution in ticks
+     * @param delay Delay before execution in ticks
      * @return WrappedTask instance
      */
     WrappedTask runAtLocationLater(Location location, Runnable runnable, long delay);
@@ -255,10 +235,9 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param location Location to run the task at
      * @param consumer Task to run
-     * @param delay    Delay before execution in ticks
+     * @param delay Delay before execution in ticks
      */
     void runAtLocationLater(Location location, Consumer<WrappedTask> consumer, long delay);
 
@@ -266,11 +245,10 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param location Location to run the task at
      * @param runnable Task to run
-     * @param delay    Delay before execution
-     * @param unit     Time unit
+     * @param delay Delay before execution
+     * @param unit Time unit
      * @return WrappedTask instance
      */
     WrappedTask runAtLocationLater(Location location, Runnable runnable, long delay, TimeUnit unit);
@@ -279,11 +257,10 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param location Location to run the task at
      * @param consumer Task to run
-     * @param delay    Delay before execution
-     * @param unit     Time unit
+     * @param delay Delay before execution
+     * @param unit Time unit
      */
     void runAtLocationLater(Location location, Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
@@ -291,11 +268,10 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param location Location to run the task at
      * @param runnable Task to run
-     * @param delay    Delay before first execution in ticks
-     * @param period   Delay between executions in ticks
+     * @param delay Delay before first execution in ticks
+     * @param period Delay between executions in ticks
      * @return WrappedTask instance
      */
     WrappedTask runAtLocationTimer(Location location, Runnable runnable, long delay, long period);
@@ -304,11 +280,10 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param location Location to run the task at
      * @param consumer Task to run
-     * @param delay    Delay before first execution in ticks
-     * @param period   Delay between executions in ticks
+     * @param delay Delay before first execution in ticks
+     * @param period Delay between executions in ticks
      */
     void runAtLocationTimer(Location location, Consumer<WrappedTask> consumer, long delay, long period);
 
@@ -316,12 +291,11 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param location Location to run the task at
      * @param runnable Task to run
-     * @param delay    Delay before first execution
-     * @param period   Delay between executions
-     * @param unit     Time unit
+     * @param delay Delay before first execution
+     * @param period Delay between executions
+     * @param unit Time unit
      * @return WrappedTask instance
      */
     WrappedTask runAtLocationTimer(Location location, Runnable runnable, long delay, long period, TimeUnit unit);
@@ -330,12 +304,11 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
      * @param location Location to run the task at
      * @param consumer Task to run
-     * @param delay    Delay before first execution
-     * @param period   Delay between executions
-     * @param unit     Time unit
+     * @param delay Delay before first execution
+     * @param period Delay between executions
+     * @param unit Time unit
      */
     void runAtLocationTimer(Location location, Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit);
 
@@ -346,8 +319,7 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
-     * @param entity   Entity to run the task at
+     * @param entity Entity to run the task at
      * @param consumer Task to run
      * @return Future when the task is completed
      */
@@ -357,8 +329,7 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
-     * @param entity   Entity to run the task at
+     * @param entity Entity to run the task at
      * @param consumer Task to run
      * @return Future when the task is completed
      */
@@ -368,10 +339,9 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
-     * @param entity   Entity to run the task at
+     * @param entity Entity to run the task at
      * @param runnable Task to run
-     * @param delay    Delay before execution in ticks
+     * @param delay Delay before execution in ticks
      * @return WrappedTask instance
      */
     WrappedTask runAtEntityLater(Entity entity, Runnable runnable, long delay);
@@ -380,10 +350,9 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
-     * @param entity   Entity to run the task at
+     * @param entity Entity to run the task at
      * @param consumer Task to run
-     * @param delay    Delay before execution in ticks
+     * @param delay Delay before execution in ticks
      */
     void runAtEntityLater(Entity entity, Consumer<WrappedTask> consumer, long delay);
 
@@ -391,11 +360,10 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
-     * @param entity   Entity to run the task at
+     * @param entity Entity to run the task at
      * @param runnable Task to run
-     * @param delay    Delay before execution
-     * @param unit     Time unit
+     * @param delay Delay before execution
+     * @param unit Time unit
      * @return WrappedTask instance
      */
     WrappedTask runAtEntityLater(Entity entity, Runnable runnable, long delay, TimeUnit unit);
@@ -404,11 +372,10 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
-     * @param entity   Entity to run the task at
+     * @param entity Entity to run the task at
      * @param consumer Task to run
-     * @param delay    Delay before execution
-     * @param unit     Time unit
+     * @param delay Delay before execution
+     * @param unit Time unit
      */
     void runAtEntityLater(Entity entity, Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
@@ -416,11 +383,10 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
-     * @param entity   Entity to run the task at
+     * @param entity Entity to run the task at
      * @param runnable Task to run
-     * @param delay    Delay before first execution in ticks
-     * @param period   Delay between executions in ticks
+     * @param delay Delay before first execution in ticks
+     * @param period Delay between executions in ticks
      * @return WrappedTask instance
      */
     WrappedTask runAtEntityTimer(Entity entity, Runnable runnable, long delay, long period);
@@ -429,11 +395,10 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
-     * @param entity   Entity to run the task at
+     * @param entity Entity to run the task at
      * @param consumer Task to run
-     * @param delay    Delay before first execution in ticks
-     * @param period   Delay between executions in ticks
+     * @param delay Delay before first execution in ticks
+     * @param period Delay between executions in ticks
      */
     void runAtEntityTimer(Entity entity, Consumer<WrappedTask> consumer, long delay, long period);
 
@@ -441,12 +406,11 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
-     * @param entity   Entity to run the task at
+     * @param entity Entity to run the task at
      * @param runnable Task to run
-     * @param delay    Delay before first execution
-     * @param period   Delay between executions
-     * @param unit     Time unit
+     * @param delay Delay before first execution
+     * @param period Delay between executions
+     * @param unit Time unit
      * @return WrappedTask instance
      */
     WrappedTask runAtEntityTimer(Entity entity, Runnable runnable, long delay, long period, TimeUnit unit);
@@ -455,18 +419,16 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     *
-     * @param entity   Entity to run the task at
+     * @param entity Entity to run the task at
      * @param consumer Task to run
-     * @param delay    Delay before first execution
-     * @param period   Delay between executions
-     * @param unit     Time unit
+     * @param delay Delay before first execution
+     * @param period Delay between executions
+     * @param unit Time unit
      */
     void runAtEntityTimer(Entity entity, Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit);
 
     /**
      * Cancel a task
-     *
      * @param task Task to cancel
      */
     void cancelTask(WrappedTask task);
@@ -480,7 +442,6 @@ public interface ServerImplementation {
      * Get a player by name (approximately).
      * When using folia, this can be run sync or async. If this is run async on non-folia platforms, it will block
      * until the next tick to get the player safely.
-     *
      * @param name Name of the player
      * @return Player instance or null if not found
      */
@@ -490,7 +451,6 @@ public interface ServerImplementation {
      * Get a player by name (exactly)
      * When using folia, this can be run sync or async. If this is run async on non-folia platforms, it will block
      * until the next tick to get the player safely.
-     *
      * @param name Name of the player
      * @return Player instance or null if not found
      */
@@ -500,26 +460,28 @@ public interface ServerImplementation {
      * Get a player by UUID
      * When using folia, this can be run sync or async. If this is run async on non-folia platforms, it will block
      * until the next tick to get the player safely.
-     *
      * @param uuid UUID of the player
      * @return Player instance or null if not found
      */
     Player getPlayer(UUID uuid);
 
     /**
-     * Teleport a player to a location async
-     *
+     * Teleport an entity to a location async
+     * @param cause Who cause the teleporting
      * @return Future when the teleport is completed or failed
      */
     CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, TeleportCause cause);
 
+    /**
+     * Teleport an entity to a location async (Plugin causes)
+     * @return Future when the teleport is completed or failed
+     */
     default CompletableFuture<Boolean> teleportAsync(Entity entity, Location location) {
         return teleportAsync(entity, location, TeleportCause.PLUGIN);
     }
 
     /**
      * Wraps a native task (Folia or Bukkit) into a WrappedTask
-     *
      * @param nativeTask The native task object
      * @return WrappedTask instance
      */

--- a/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
+++ b/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
@@ -5,6 +5,7 @@ import com.tcoded.folialib.wrapper.task.WrappedTask;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -20,6 +21,7 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param consumer Task to run
      * @return Future when the task is completed
      */
@@ -29,6 +31,7 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
+     *
      * @param consumer Task to run
      * @return Future when the task is completed
      */
@@ -40,8 +43,9 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param runnable Task to run
-     * @param delay Delay before execution in ticks
+     * @param delay    Delay before execution in ticks
      * @return WrappedTask instance
      */
     WrappedTask runLater(Runnable runnable, long delay);
@@ -50,8 +54,9 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param consumer Task to run
-     * @param delay Delay before execution in ticks
+     * @param delay    Delay before execution in ticks
      */
     void runLater(Consumer<WrappedTask> consumer, long delay);
 
@@ -59,9 +64,10 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param runnable Task to run
-     * @param delay Delay before execution
-     * @param unit Time unit
+     * @param delay    Delay before execution
+     * @param unit     Time unit
      * @return WrappedTask instance
      */
     WrappedTask runLater(Runnable runnable, long delay, TimeUnit unit);
@@ -70,9 +76,10 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param consumer Task to run
-     * @param delay Delay before execution
-     * @param unit Time unit
+     * @param delay    Delay before execution
+     * @param unit     Time unit
      */
     void runLater(Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
@@ -80,8 +87,9 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
+     *
      * @param runnable Task to run
-     * @param delay Delay before execution in ticks
+     * @param delay    Delay before execution in ticks
      * @return WrappedTask instance
      */
     WrappedTask runLaterAsync(Runnable runnable, long delay);
@@ -90,8 +98,9 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
+     *
      * @param consumer Task to run
-     * @param delay Delay before execution in ticks
+     * @param delay    Delay before execution in ticks
      */
     void runLaterAsync(Consumer<WrappedTask> consumer, long delay);
 
@@ -99,9 +108,10 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
+     *
      * @param runnable Task to run
-     * @param delay Delay before execution
-     * @param unit Time unit
+     * @param delay    Delay before execution
+     * @param unit     Time unit
      * @return WrappedTask instance
      */
     WrappedTask runLaterAsync(Runnable runnable, long delay, TimeUnit unit);
@@ -110,9 +120,10 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
+     *
      * @param consumer Task to run
-     * @param delay Delay before execution
-     * @param unit Time unit
+     * @param delay    Delay before execution
+     * @param unit     Time unit
      */
     void runLaterAsync(Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
@@ -122,9 +133,10 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param runnable Task to run
-     * @param delay Delay before first execution in ticks
-     * @param period Delay between executions in ticks
+     * @param delay    Delay before first execution in ticks
+     * @param period   Delay between executions in ticks
      * @return WrappedTask instance
      */
     WrappedTask runTimer(Runnable runnable, long delay, long period);
@@ -133,9 +145,10 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param consumer Task to run
-     * @param delay Delay before first execution in ticks
-     * @param period Delay between executions in ticks
+     * @param delay    Delay before first execution in ticks
+     * @param period   Delay between executions in ticks
      */
     void runTimer(Consumer<WrappedTask> consumer, long delay, long period);
 
@@ -143,10 +156,11 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param runnable Task to run
-     * @param delay Delay before first execution
-     * @param period Delay between executions
-     * @param unit Time unit
+     * @param delay    Delay before first execution
+     * @param period   Delay between executions
+     * @param unit     Time unit
      * @return WrappedTask instance
      */
     WrappedTask runTimer(Runnable runnable, long delay, long period, TimeUnit unit);
@@ -155,10 +169,11 @@ public interface ServerImplementation {
      * Folia: Synced with the server daylight cycle tick
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param consumer Task to run
-     * @param delay Delay before first execution
-     * @param period Delay between executions
-     * @param unit Time unit
+     * @param delay    Delay before first execution
+     * @param period   Delay between executions
+     * @param unit     Time unit
      */
     void runTimer(Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit);
 
@@ -166,9 +181,10 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
+     *
      * @param runnable Task to run
-     * @param delay Delay before first execution in ticks
-     * @param period Delay between executions in ticks
+     * @param delay    Delay before first execution in ticks
+     * @param period   Delay between executions in ticks
      * @return WrappedTask instance
      */
     WrappedTask runTimerAsync(Runnable runnable, long delay, long period);
@@ -177,9 +193,10 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
+     *
      * @param consumer Task to run
-     * @param delay Delay before first execution in ticks
-     * @param period Delay between executions in ticks
+     * @param delay    Delay before first execution in ticks
+     * @param period   Delay between executions in ticks
      */
     void runTimerAsync(Consumer<WrappedTask> consumer, long delay, long period);
 
@@ -187,10 +204,11 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
+     *
      * @param runnable Task to run
-     * @param delay Delay before first execution
-     * @param period Delay between executions
-     * @param unit Time unit
+     * @param delay    Delay before first execution
+     * @param period   Delay between executions
+     * @param unit     Time unit
      * @return WrappedTask instance
      */
     WrappedTask runTimerAsync(Runnable runnable, long delay, long period, TimeUnit unit);
@@ -199,10 +217,11 @@ public interface ServerImplementation {
      * Folia: Async
      * Paper: Async
      * Spigot: Async
+     *
      * @param consumer Task to run
-     * @param delay Delay before first execution
-     * @param period Delay between executions
-     * @param unit Time unit
+     * @param delay    Delay before first execution
+     * @param period   Delay between executions
+     * @param unit     Time unit
      */
     void runTimerAsync(Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit);
 
@@ -213,6 +232,7 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param location Location to run the task at
      * @param consumer Task to run
      * @return Future when the task is completed
@@ -223,9 +243,10 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param location Location to run the task at
      * @param runnable Task to run
-     * @param delay Delay before execution in ticks
+     * @param delay    Delay before execution in ticks
      * @return WrappedTask instance
      */
     WrappedTask runAtLocationLater(Location location, Runnable runnable, long delay);
@@ -234,9 +255,10 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param location Location to run the task at
      * @param consumer Task to run
-     * @param delay Delay before execution in ticks
+     * @param delay    Delay before execution in ticks
      */
     void runAtLocationLater(Location location, Consumer<WrappedTask> consumer, long delay);
 
@@ -244,10 +266,11 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param location Location to run the task at
      * @param runnable Task to run
-     * @param delay Delay before execution
-     * @param unit Time unit
+     * @param delay    Delay before execution
+     * @param unit     Time unit
      * @return WrappedTask instance
      */
     WrappedTask runAtLocationLater(Location location, Runnable runnable, long delay, TimeUnit unit);
@@ -256,10 +279,11 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param location Location to run the task at
      * @param consumer Task to run
-     * @param delay Delay before execution
-     * @param unit Time unit
+     * @param delay    Delay before execution
+     * @param unit     Time unit
      */
     void runAtLocationLater(Location location, Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
@@ -267,10 +291,11 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param location Location to run the task at
      * @param runnable Task to run
-     * @param delay Delay before first execution in ticks
-     * @param period Delay between executions in ticks
+     * @param delay    Delay before first execution in ticks
+     * @param period   Delay between executions in ticks
      * @return WrappedTask instance
      */
     WrappedTask runAtLocationTimer(Location location, Runnable runnable, long delay, long period);
@@ -279,10 +304,11 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param location Location to run the task at
      * @param consumer Task to run
-     * @param delay Delay before first execution in ticks
-     * @param period Delay between executions in ticks
+     * @param delay    Delay before first execution in ticks
+     * @param period   Delay between executions in ticks
      */
     void runAtLocationTimer(Location location, Consumer<WrappedTask> consumer, long delay, long period);
 
@@ -290,11 +316,12 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param location Location to run the task at
      * @param runnable Task to run
-     * @param delay Delay before first execution
-     * @param period Delay between executions
-     * @param unit Time unit
+     * @param delay    Delay before first execution
+     * @param period   Delay between executions
+     * @param unit     Time unit
      * @return WrappedTask instance
      */
     WrappedTask runAtLocationTimer(Location location, Runnable runnable, long delay, long period, TimeUnit unit);
@@ -303,11 +330,12 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the chunk of the location
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
+     *
      * @param location Location to run the task at
      * @param consumer Task to run
-     * @param delay Delay before first execution
-     * @param period Delay between executions
-     * @param unit Time unit
+     * @param delay    Delay before first execution
+     * @param period   Delay between executions
+     * @param unit     Time unit
      */
     void runAtLocationTimer(Location location, Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit);
 
@@ -318,7 +346,8 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     * @param entity Entity to run the task at
+     *
+     * @param entity   Entity to run the task at
      * @param consumer Task to run
      * @return Future when the task is completed
      */
@@ -328,7 +357,8 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     * @param entity Entity to run the task at
+     *
+     * @param entity   Entity to run the task at
      * @param consumer Task to run
      * @return Future when the task is completed
      */
@@ -338,9 +368,10 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     * @param entity Entity to run the task at
+     *
+     * @param entity   Entity to run the task at
      * @param runnable Task to run
-     * @param delay Delay before execution in ticks
+     * @param delay    Delay before execution in ticks
      * @return WrappedTask instance
      */
     WrappedTask runAtEntityLater(Entity entity, Runnable runnable, long delay);
@@ -349,9 +380,10 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     * @param entity Entity to run the task at
+     *
+     * @param entity   Entity to run the task at
      * @param consumer Task to run
-     * @param delay Delay before execution in ticks
+     * @param delay    Delay before execution in ticks
      */
     void runAtEntityLater(Entity entity, Consumer<WrappedTask> consumer, long delay);
 
@@ -359,10 +391,11 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     * @param entity Entity to run the task at
+     *
+     * @param entity   Entity to run the task at
      * @param runnable Task to run
-     * @param delay Delay before execution
-     * @param unit Time unit
+     * @param delay    Delay before execution
+     * @param unit     Time unit
      * @return WrappedTask instance
      */
     WrappedTask runAtEntityLater(Entity entity, Runnable runnable, long delay, TimeUnit unit);
@@ -371,10 +404,11 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     * @param entity Entity to run the task at
+     *
+     * @param entity   Entity to run the task at
      * @param consumer Task to run
-     * @param delay Delay before execution
-     * @param unit Time unit
+     * @param delay    Delay before execution
+     * @param unit     Time unit
      */
     void runAtEntityLater(Entity entity, Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
@@ -382,10 +416,11 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     * @param entity Entity to run the task at
+     *
+     * @param entity   Entity to run the task at
      * @param runnable Task to run
-     * @param delay Delay before first execution in ticks
-     * @param period Delay between executions in ticks
+     * @param delay    Delay before first execution in ticks
+     * @param period   Delay between executions in ticks
      * @return WrappedTask instance
      */
     WrappedTask runAtEntityTimer(Entity entity, Runnable runnable, long delay, long period);
@@ -394,10 +429,11 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     * @param entity Entity to run the task at
+     *
+     * @param entity   Entity to run the task at
      * @param consumer Task to run
-     * @param delay Delay before first execution in ticks
-     * @param period Delay between executions in ticks
+     * @param delay    Delay before first execution in ticks
+     * @param period   Delay between executions in ticks
      */
     void runAtEntityTimer(Entity entity, Consumer<WrappedTask> consumer, long delay, long period);
 
@@ -405,11 +441,12 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     * @param entity Entity to run the task at
+     *
+     * @param entity   Entity to run the task at
      * @param runnable Task to run
-     * @param delay Delay before first execution
-     * @param period Delay between executions
-     * @param unit Time unit
+     * @param delay    Delay before first execution
+     * @param period   Delay between executions
+     * @param unit     Time unit
      * @return WrappedTask instance
      */
     WrappedTask runAtEntityTimer(Entity entity, Runnable runnable, long delay, long period, TimeUnit unit);
@@ -418,16 +455,18 @@ public interface ServerImplementation {
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
-     * @param entity Entity to run the task at
+     *
+     * @param entity   Entity to run the task at
      * @param consumer Task to run
-     * @param delay Delay before first execution
-     * @param period Delay between executions
-     * @param unit Time unit
+     * @param delay    Delay before first execution
+     * @param period   Delay between executions
+     * @param unit     Time unit
      */
     void runAtEntityTimer(Entity entity, Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit);
 
     /**
      * Cancel a task
+     *
      * @param task Task to cancel
      */
     void cancelTask(WrappedTask task);
@@ -441,6 +480,7 @@ public interface ServerImplementation {
      * Get a player by name (approximately).
      * When using folia, this can be run sync or async. If this is run async on non-folia platforms, it will block
      * until the next tick to get the player safely.
+     *
      * @param name Name of the player
      * @return Player instance or null if not found
      */
@@ -450,6 +490,7 @@ public interface ServerImplementation {
      * Get a player by name (exactly)
      * When using folia, this can be run sync or async. If this is run async on non-folia platforms, it will block
      * until the next tick to get the player safely.
+     *
      * @param name Name of the player
      * @return Player instance or null if not found
      */
@@ -459,6 +500,7 @@ public interface ServerImplementation {
      * Get a player by UUID
      * When using folia, this can be run sync or async. If this is run async on non-folia platforms, it will block
      * until the next tick to get the player safely.
+     *
      * @param uuid UUID of the player
      * @return Player instance or null if not found
      */
@@ -466,12 +508,18 @@ public interface ServerImplementation {
 
     /**
      * Teleport a player to a location async
+     *
      * @return Future when the teleport is completed or failed
      */
-    CompletableFuture<Boolean> teleportAsync(Player player, Location location);
+    CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, TeleportCause cause);
+
+    default CompletableFuture<Boolean> teleportAsync(Entity entity, Location location) {
+        return teleportAsync(entity, location, TeleportCause.PLUGIN);
+    }
 
     /**
      * Wraps a native task (Folia or Bukkit) into a WrappedTask
+     *
      * @param nativeTask The native task object
      * @return WrappedTask instance
      */

--- a/platform/folia/src/main/java/com/tcoded/folialib/impl/FoliaImplementation.java
+++ b/platform/folia/src/main/java/com/tcoded/folialib/impl/FoliaImplementation.java
@@ -12,6 +12,7 @@ import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.UUID;
@@ -33,7 +34,7 @@ public class FoliaImplementation implements ServerImplementation {
         this.asyncScheduler = plugin.getServer().getAsyncScheduler();
     }
 
-	@Override
+    @Override
     public CompletableFuture<Void> runNextTick(Consumer<WrappedTask> consumer) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
@@ -45,7 +46,7 @@ public class FoliaImplementation implements ServerImplementation {
         return future;
     }
 
-	@Override
+    @Override
     public CompletableFuture<Void> runAsync(Consumer<WrappedTask> consumer) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
@@ -57,7 +58,7 @@ public class FoliaImplementation implements ServerImplementation {
         return future;
     }
 
-	@Override
+    @Override
     public WrappedTask runLater(Runnable runnable, long delay) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -66,7 +67,7 @@ public class FoliaImplementation implements ServerImplementation {
         return this.wrapTask(this.globalRegionScheduler.runDelayed(plugin, task -> runnable.run(), delay));
     }
 
-	@Override
+    @Override
     public void runLater(Consumer<WrappedTask> consumer, long delay) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -75,39 +76,39 @@ public class FoliaImplementation implements ServerImplementation {
         this.globalRegionScheduler.runDelayed(plugin, task -> consumer.accept(this.wrapTask(task)), delay);
     }
 
-	@Override
+    @Override
     public WrappedTask runLater(Runnable runnable, long delay, TimeUnit unit) {
         return this.runLater(runnable, TimeConverter.toTicks(delay, unit));
     }
 
-	@Override
+    @Override
     public void runLater(Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         this.runLater(consumer, TimeConverter.toTicks(delay, unit));
     }
 
-	@Override
+    @Override
     public WrappedTask runLaterAsync(Runnable runnable, long delay) {
         return this.runLaterAsync(runnable, TimeConverter.toMillis(delay), TimeUnit.MILLISECONDS);
     }
 
-	@Override
+    @Override
     public void runLaterAsync(Consumer<WrappedTask> consumer, long delay) {
         this.runLaterAsync(consumer, TimeConverter.toMillis(delay), TimeUnit.MILLISECONDS);
     }
 
-	@Override
+    @Override
     public WrappedTask runLaterAsync(Runnable runnable, long delay, TimeUnit unit) {
         return this.wrapTask(
                 this.asyncScheduler.runDelayed(plugin, task -> runnable.run(), delay, unit)
         );
     }
 
-	@Override
+    @Override
     public void runLaterAsync(Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         this.asyncScheduler.runDelayed(plugin, task -> consumer.accept(this.wrapTask(task)), delay, unit);
     }
 
-	@Override
+    @Override
     public WrappedTask runTimer(Runnable runnable, long delay, long period) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -122,7 +123,7 @@ public class FoliaImplementation implements ServerImplementation {
         );
     }
 
-	@Override
+    @Override
     public void runTimer(Consumer<WrappedTask> consumer, long delay, long period) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -135,43 +136,43 @@ public class FoliaImplementation implements ServerImplementation {
         this.globalRegionScheduler.runAtFixedRate(plugin, task -> consumer.accept(this.wrapTask(task)), delay, period);
     }
 
-	@Override
+    @Override
     public WrappedTask runTimer(Runnable runnable, long delay, long period, TimeUnit unit) {
         return this.runTimer(runnable, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
-	@Override
+    @Override
     public void runTimer(Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit) {
         this.runTimer(consumer, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
-	@Override
+    @Override
     public WrappedTask runTimerAsync(Runnable runnable, long delay, long period) {
         return this.runTimerAsync(
                 runnable, TimeConverter.toMillis(delay), TimeConverter.toMillis(period), TimeUnit.MILLISECONDS
         );
     }
 
-	@Override
+    @Override
     public void runTimerAsync(Consumer<WrappedTask> consumer, long delay, long period) {
         this.runTimerAsync(
                 consumer, TimeConverter.toMillis(delay), TimeConverter.toMillis(period), TimeUnit.MILLISECONDS
         );
     }
 
-	@Override
+    @Override
     public WrappedTask runTimerAsync(Runnable runnable, long delay, long period, TimeUnit unit) {
         return this.wrapTask(
                 this.asyncScheduler.runAtFixedRate(plugin, task -> runnable.run(), delay, period, unit)
         );
     }
 
-	@Override
+    @Override
     public void runTimerAsync(Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit) {
         this.asyncScheduler.runAtFixedRate(plugin, task -> consumer.accept(this.wrapTask(task)), delay, period, unit);
     }
 
-	@Override
+    @Override
     public CompletableFuture<Void> runAtLocation(Location location, Consumer<WrappedTask> consumer) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
@@ -183,7 +184,7 @@ public class FoliaImplementation implements ServerImplementation {
         return future;
     }
 
-	@Override
+    @Override
     public WrappedTask runAtLocationLater(Location location, Runnable runnable, long delay) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -194,7 +195,7 @@ public class FoliaImplementation implements ServerImplementation {
         );
     }
 
-	@Override
+    @Override
     public void runAtLocationLater(Location location, Consumer<WrappedTask> consumer, long delay) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -203,17 +204,17 @@ public class FoliaImplementation implements ServerImplementation {
         this.plugin.getServer().getRegionScheduler().runDelayed(plugin, location, task -> consumer.accept(this.wrapTask(task)), delay);
     }
 
-	@Override
+    @Override
     public WrappedTask runAtLocationLater(Location location, Runnable runnable, long delay, TimeUnit unit) {
         return this.runAtLocationLater(location, runnable, TimeConverter.toTicks(delay, unit));
     }
 
-	@Override
+    @Override
     public void runAtLocationLater(Location location, Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         this.runAtLocationLater(location, consumer, TimeConverter.toTicks(delay, unit));
     }
 
-	@Override
+    @Override
     public WrappedTask runAtLocationTimer(Location location, Runnable runnable, long delay, long period) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -228,7 +229,7 @@ public class FoliaImplementation implements ServerImplementation {
         );
     }
 
-	@Override
+    @Override
     public void runAtLocationTimer(Location location, Consumer<WrappedTask> consumer, long delay, long period) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -241,17 +242,17 @@ public class FoliaImplementation implements ServerImplementation {
         this.plugin.getServer().getRegionScheduler().runAtFixedRate(plugin, location, task -> consumer.accept(this.wrapTask(task)), delay, period);
     }
 
-	@Override
+    @Override
     public WrappedTask runAtLocationTimer(Location location, Runnable runnable, long delay, long period, TimeUnit unit) {
         return this.runAtLocationTimer(location, runnable, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
-	@Override
+    @Override
     public void runAtLocationTimer(Location location, Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit) {
         this.runAtLocationTimer(location, consumer, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
-	@Override
+    @Override
     public CompletableFuture<EntityTaskResult> runAtEntity(Entity entity, Consumer<WrappedTask> consumer) {
         CompletableFuture<EntityTaskResult> future = new CompletableFuture<>();
 
@@ -267,7 +268,7 @@ public class FoliaImplementation implements ServerImplementation {
         return future;
     }
 
-	@Override
+    @Override
     public CompletableFuture<EntityTaskResult> runAtEntityWithFallback(Entity entity, Consumer<WrappedTask> consumer, Runnable fallback) {
         CompletableFuture<EntityTaskResult> future = new CompletableFuture<>();
 
@@ -286,7 +287,7 @@ public class FoliaImplementation implements ServerImplementation {
         return future;
     }
 
-	@Override
+    @Override
     public WrappedTask runAtEntityLater(Entity entity, Runnable runnable, long delay) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -295,7 +296,7 @@ public class FoliaImplementation implements ServerImplementation {
         return this.wrapTask(entity.getScheduler().runDelayed(plugin, task -> runnable.run(), null, delay));
     }
 
-	@Override
+    @Override
     public void runAtEntityLater(Entity entity, Consumer<WrappedTask> consumer, long delay) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -304,17 +305,17 @@ public class FoliaImplementation implements ServerImplementation {
         entity.getScheduler().runDelayed(plugin, task -> consumer.accept(this.wrapTask(task)), null, delay);
     }
 
-	@Override
+    @Override
     public WrappedTask runAtEntityLater(Entity entity, Runnable runnable, long delay, TimeUnit unit) {
         return this.runAtEntityLater(entity, runnable, TimeConverter.toTicks(delay, unit));
     }
 
-	@Override
+    @Override
     public void runAtEntityLater(Entity entity, Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         this.runAtEntityLater(entity, consumer, TimeConverter.toTicks(delay, unit));
     }
 
-	@Override
+    @Override
     public WrappedTask runAtEntityTimer(Entity entity, Runnable runnable, long delay, long period) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -329,7 +330,7 @@ public class FoliaImplementation implements ServerImplementation {
         );
     }
 
-	@Override
+    @Override
     public void runAtEntityTimer(Entity entity, Consumer<WrappedTask> consumer, long delay, long period) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -342,51 +343,51 @@ public class FoliaImplementation implements ServerImplementation {
         entity.getScheduler().runAtFixedRate(plugin, task -> consumer.accept(this.wrapTask(task)), null, delay, period);
     }
 
-	@Override
+    @Override
     public WrappedTask runAtEntityTimer(Entity entity, Runnable runnable, long delay, long period, TimeUnit unit) {
         return this.runAtEntityTimer(entity, runnable, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
-	@Override
+    @Override
     public void runAtEntityTimer(Entity entity, Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit) {
         this.runAtEntityTimer(entity, consumer, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
-	@Override
+    @Override
     public void cancelTask(WrappedTask task) {
         task.cancel();
     }
 
-	@Override
+    @Override
     public void cancelAllTasks() {
         this.globalRegionScheduler.cancelTasks(plugin);
         this.asyncScheduler.cancelTasks(plugin);
     }
 
-	@Override
+    @Override
     public Player getPlayer(String name) {
         // This is thread-safe in folia
         return this.plugin.getServer().getPlayer(name);
     }
 
-	@Override
+    @Override
     public Player getPlayerExact(String name) {
         // This is thread-safe in folia
         return this.plugin.getServer().getPlayerExact(name);
     }
 
-	@Override
+    @Override
     public Player getPlayer(UUID uuid) {
         // This is thread-safe in folia
         return this.plugin.getServer().getPlayer(uuid);
     }
 
-	@Override
-    public CompletableFuture<Boolean> teleportAsync(Player player, Location location) {
-        return player.teleportAsync(location);
+    @Override
+    public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause) {
+        return entity.teleportAsync(location, cause);
     }
 
-	@Override
+    @Override
     public WrappedTask wrapTask(Object nativeTask) {
         if (!(nativeTask instanceof ScheduledTask)) {
             throw new IllegalArgumentException("The nativeTask provided must be a ScheduledTask. Got: " + nativeTask.getClass().getName() + " instead.");

--- a/platform/folia/src/main/java/com/tcoded/folialib/impl/FoliaImplementation.java
+++ b/platform/folia/src/main/java/com/tcoded/folialib/impl/FoliaImplementation.java
@@ -12,7 +12,7 @@ import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.UUID;
@@ -34,7 +34,7 @@ public class FoliaImplementation implements ServerImplementation {
         this.asyncScheduler = plugin.getServer().getAsyncScheduler();
     }
 
-    @Override
+	@Override
     public CompletableFuture<Void> runNextTick(Consumer<WrappedTask> consumer) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
@@ -46,7 +46,7 @@ public class FoliaImplementation implements ServerImplementation {
         return future;
     }
 
-    @Override
+	@Override
     public CompletableFuture<Void> runAsync(Consumer<WrappedTask> consumer) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
@@ -58,7 +58,7 @@ public class FoliaImplementation implements ServerImplementation {
         return future;
     }
 
-    @Override
+	@Override
     public WrappedTask runLater(Runnable runnable, long delay) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -67,7 +67,7 @@ public class FoliaImplementation implements ServerImplementation {
         return this.wrapTask(this.globalRegionScheduler.runDelayed(plugin, task -> runnable.run(), delay));
     }
 
-    @Override
+	@Override
     public void runLater(Consumer<WrappedTask> consumer, long delay) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -76,39 +76,39 @@ public class FoliaImplementation implements ServerImplementation {
         this.globalRegionScheduler.runDelayed(plugin, task -> consumer.accept(this.wrapTask(task)), delay);
     }
 
-    @Override
+	@Override
     public WrappedTask runLater(Runnable runnable, long delay, TimeUnit unit) {
         return this.runLater(runnable, TimeConverter.toTicks(delay, unit));
     }
 
-    @Override
+	@Override
     public void runLater(Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         this.runLater(consumer, TimeConverter.toTicks(delay, unit));
     }
 
-    @Override
+	@Override
     public WrappedTask runLaterAsync(Runnable runnable, long delay) {
         return this.runLaterAsync(runnable, TimeConverter.toMillis(delay), TimeUnit.MILLISECONDS);
     }
 
-    @Override
+	@Override
     public void runLaterAsync(Consumer<WrappedTask> consumer, long delay) {
         this.runLaterAsync(consumer, TimeConverter.toMillis(delay), TimeUnit.MILLISECONDS);
     }
 
-    @Override
+	@Override
     public WrappedTask runLaterAsync(Runnable runnable, long delay, TimeUnit unit) {
         return this.wrapTask(
                 this.asyncScheduler.runDelayed(plugin, task -> runnable.run(), delay, unit)
         );
     }
 
-    @Override
+	@Override
     public void runLaterAsync(Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         this.asyncScheduler.runDelayed(plugin, task -> consumer.accept(this.wrapTask(task)), delay, unit);
     }
 
-    @Override
+	@Override
     public WrappedTask runTimer(Runnable runnable, long delay, long period) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -123,7 +123,7 @@ public class FoliaImplementation implements ServerImplementation {
         );
     }
 
-    @Override
+	@Override
     public void runTimer(Consumer<WrappedTask> consumer, long delay, long period) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -136,43 +136,43 @@ public class FoliaImplementation implements ServerImplementation {
         this.globalRegionScheduler.runAtFixedRate(plugin, task -> consumer.accept(this.wrapTask(task)), delay, period);
     }
 
-    @Override
+	@Override
     public WrappedTask runTimer(Runnable runnable, long delay, long period, TimeUnit unit) {
         return this.runTimer(runnable, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
-    @Override
+	@Override
     public void runTimer(Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit) {
         this.runTimer(consumer, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
-    @Override
+	@Override
     public WrappedTask runTimerAsync(Runnable runnable, long delay, long period) {
         return this.runTimerAsync(
                 runnable, TimeConverter.toMillis(delay), TimeConverter.toMillis(period), TimeUnit.MILLISECONDS
         );
     }
 
-    @Override
+	@Override
     public void runTimerAsync(Consumer<WrappedTask> consumer, long delay, long period) {
         this.runTimerAsync(
                 consumer, TimeConverter.toMillis(delay), TimeConverter.toMillis(period), TimeUnit.MILLISECONDS
         );
     }
 
-    @Override
+	@Override
     public WrappedTask runTimerAsync(Runnable runnable, long delay, long period, TimeUnit unit) {
         return this.wrapTask(
                 this.asyncScheduler.runAtFixedRate(plugin, task -> runnable.run(), delay, period, unit)
         );
     }
 
-    @Override
+	@Override
     public void runTimerAsync(Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit) {
         this.asyncScheduler.runAtFixedRate(plugin, task -> consumer.accept(this.wrapTask(task)), delay, period, unit);
     }
 
-    @Override
+	@Override
     public CompletableFuture<Void> runAtLocation(Location location, Consumer<WrappedTask> consumer) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
@@ -184,7 +184,7 @@ public class FoliaImplementation implements ServerImplementation {
         return future;
     }
 
-    @Override
+	@Override
     public WrappedTask runAtLocationLater(Location location, Runnable runnable, long delay) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -195,7 +195,7 @@ public class FoliaImplementation implements ServerImplementation {
         );
     }
 
-    @Override
+	@Override
     public void runAtLocationLater(Location location, Consumer<WrappedTask> consumer, long delay) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -204,17 +204,17 @@ public class FoliaImplementation implements ServerImplementation {
         this.plugin.getServer().getRegionScheduler().runDelayed(plugin, location, task -> consumer.accept(this.wrapTask(task)), delay);
     }
 
-    @Override
+	@Override
     public WrappedTask runAtLocationLater(Location location, Runnable runnable, long delay, TimeUnit unit) {
         return this.runAtLocationLater(location, runnable, TimeConverter.toTicks(delay, unit));
     }
 
-    @Override
+	@Override
     public void runAtLocationLater(Location location, Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         this.runAtLocationLater(location, consumer, TimeConverter.toTicks(delay, unit));
     }
 
-    @Override
+	@Override
     public WrappedTask runAtLocationTimer(Location location, Runnable runnable, long delay, long period) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -229,7 +229,7 @@ public class FoliaImplementation implements ServerImplementation {
         );
     }
 
-    @Override
+	@Override
     public void runAtLocationTimer(Location location, Consumer<WrappedTask> consumer, long delay, long period) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -242,17 +242,17 @@ public class FoliaImplementation implements ServerImplementation {
         this.plugin.getServer().getRegionScheduler().runAtFixedRate(plugin, location, task -> consumer.accept(this.wrapTask(task)), delay, period);
     }
 
-    @Override
+	@Override
     public WrappedTask runAtLocationTimer(Location location, Runnable runnable, long delay, long period, TimeUnit unit) {
         return this.runAtLocationTimer(location, runnable, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
-    @Override
+	@Override
     public void runAtLocationTimer(Location location, Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit) {
         this.runAtLocationTimer(location, consumer, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
-    @Override
+	@Override
     public CompletableFuture<EntityTaskResult> runAtEntity(Entity entity, Consumer<WrappedTask> consumer) {
         CompletableFuture<EntityTaskResult> future = new CompletableFuture<>();
 
@@ -268,7 +268,7 @@ public class FoliaImplementation implements ServerImplementation {
         return future;
     }
 
-    @Override
+	@Override
     public CompletableFuture<EntityTaskResult> runAtEntityWithFallback(Entity entity, Consumer<WrappedTask> consumer, Runnable fallback) {
         CompletableFuture<EntityTaskResult> future = new CompletableFuture<>();
 
@@ -287,7 +287,7 @@ public class FoliaImplementation implements ServerImplementation {
         return future;
     }
 
-    @Override
+	@Override
     public WrappedTask runAtEntityLater(Entity entity, Runnable runnable, long delay) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -296,7 +296,7 @@ public class FoliaImplementation implements ServerImplementation {
         return this.wrapTask(entity.getScheduler().runDelayed(plugin, task -> runnable.run(), null, delay));
     }
 
-    @Override
+	@Override
     public void runAtEntityLater(Entity entity, Consumer<WrappedTask> consumer, long delay) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -305,17 +305,17 @@ public class FoliaImplementation implements ServerImplementation {
         entity.getScheduler().runDelayed(plugin, task -> consumer.accept(this.wrapTask(task)), null, delay);
     }
 
-    @Override
+	@Override
     public WrappedTask runAtEntityLater(Entity entity, Runnable runnable, long delay, TimeUnit unit) {
         return this.runAtEntityLater(entity, runnable, TimeConverter.toTicks(delay, unit));
     }
 
-    @Override
+	@Override
     public void runAtEntityLater(Entity entity, Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         this.runAtEntityLater(entity, consumer, TimeConverter.toTicks(delay, unit));
     }
 
-    @Override
+	@Override
     public WrappedTask runAtEntityTimer(Entity entity, Runnable runnable, long delay, long period) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -330,7 +330,7 @@ public class FoliaImplementation implements ServerImplementation {
         );
     }
 
-    @Override
+	@Override
     public void runAtEntityTimer(Entity entity, Consumer<WrappedTask> consumer, long delay, long period) {
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
@@ -343,51 +343,51 @@ public class FoliaImplementation implements ServerImplementation {
         entity.getScheduler().runAtFixedRate(plugin, task -> consumer.accept(this.wrapTask(task)), null, delay, period);
     }
 
-    @Override
+	@Override
     public WrappedTask runAtEntityTimer(Entity entity, Runnable runnable, long delay, long period, TimeUnit unit) {
         return this.runAtEntityTimer(entity, runnable, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
-    @Override
+	@Override
     public void runAtEntityTimer(Entity entity, Consumer<WrappedTask> consumer, long delay, long period, TimeUnit unit) {
         this.runAtEntityTimer(entity, consumer, TimeConverter.toTicks(delay, unit), TimeConverter.toTicks(period, unit));
     }
 
-    @Override
+	@Override
     public void cancelTask(WrappedTask task) {
         task.cancel();
     }
 
-    @Override
+	@Override
     public void cancelAllTasks() {
         this.globalRegionScheduler.cancelTasks(plugin);
         this.asyncScheduler.cancelTasks(plugin);
     }
 
-    @Override
+	@Override
     public Player getPlayer(String name) {
         // This is thread-safe in folia
         return this.plugin.getServer().getPlayer(name);
     }
 
-    @Override
+	@Override
     public Player getPlayerExact(String name) {
         // This is thread-safe in folia
         return this.plugin.getServer().getPlayerExact(name);
     }
 
-    @Override
+	@Override
     public Player getPlayer(UUID uuid) {
         // This is thread-safe in folia
         return this.plugin.getServer().getPlayer(uuid);
     }
 
-    @Override
-    public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause) {
-        return entity.teleportAsync(location, cause);
+	@Override
+    public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, TeleportCause cause) {
+        return entity.teleportAsync(location,cause);
     }
 
-    @Override
+	@Override
     public WrappedTask wrapTask(Object nativeTask) {
         if (!(nativeTask instanceof ScheduledTask)) {
             throw new IllegalArgumentException("The nativeTask provided must be a ScheduledTask. Got: " + nativeTask.getClass().getName() + " instead.");

--- a/platform/legacy-spigot/src/main/java/com/tcoded/folialib/impl/LegacySpigotImplementation.java
+++ b/platform/legacy-spigot/src/main/java/com/tcoded/folialib/impl/LegacySpigotImplementation.java
@@ -5,11 +5,12 @@ import com.tcoded.folialib.enums.EntityTaskResult;
 import com.tcoded.folialib.util.ImplementationTestsUtil;
 import com.tcoded.folialib.util.TimeConverter;
 import com.tcoded.folialib.wrapper.task.WrappedBukkitTask;
-import com.tcoded.folialib.wrapper.task.WrappedTask;
 import com.tcoded.folialib.wrapper.task.WrappedLegacyBukkitTask;
+import com.tcoded.folialib.wrapper.task.WrappedTask;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
@@ -313,18 +314,9 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Boolean> teleportAsync(Player player, Location location) {
+    public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause) {
         CompletableFuture<Boolean> future = new CompletableFuture<>();
-
-        this.runAtEntity(player, (task) -> {
-            if (player.isValid() && player.isOnline()) {
-                player.teleport(location);
-                future.complete(true);
-            } else {
-                future.complete(false);
-            }
-        });
-
+        this.runAtEntity(entity, (task) -> future.complete(entity.teleport(location, cause)));
         return future;
     }
 
@@ -341,6 +333,7 @@ public class LegacySpigotImplementation implements ServerImplementation {
 
     /**
      * Internal util to get a player regardless of the calling thread
+     *
      * @param playerSupplier The supplier to get the player
      * @return Player or null if not found
      */

--- a/platform/legacy-spigot/src/main/java/com/tcoded/folialib/impl/LegacySpigotImplementation.java
+++ b/platform/legacy-spigot/src/main/java/com/tcoded/folialib/impl/LegacySpigotImplementation.java
@@ -5,12 +5,12 @@ import com.tcoded.folialib.enums.EntityTaskResult;
 import com.tcoded.folialib.util.ImplementationTestsUtil;
 import com.tcoded.folialib.util.TimeConverter;
 import com.tcoded.folialib.wrapper.task.WrappedBukkitTask;
-import com.tcoded.folialib.wrapper.task.WrappedLegacyBukkitTask;
 import com.tcoded.folialib.wrapper.task.WrappedTask;
+import com.tcoded.folialib.wrapper.task.WrappedLegacyBukkitTask;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
@@ -314,9 +314,22 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause) {
+    public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, TeleportCause cause) {
         CompletableFuture<Boolean> future = new CompletableFuture<>();
-        this.runAtEntity(entity, (task) -> future.complete(entity.teleport(location, cause)));
+
+        this.runAtEntity(entity, (task) -> {
+            if (entity.isValid()) {
+                if (entity instanceof Player && !((Player) entity).isOnline()) {
+                    future.complete(false);
+                } else {
+                    entity.teleport(location, cause);
+                    future.complete(true);
+                }
+            } else {
+                future.complete(false);
+            }
+        });
+
         return future;
     }
 
@@ -333,7 +346,6 @@ public class LegacySpigotImplementation implements ServerImplementation {
 
     /**
      * Internal util to get a player regardless of the calling thread
-     *
      * @param playerSupplier The supplier to get the player
      * @return Player or null if not found
      */

--- a/platform/spigot/src/main/java/com/tcoded/folialib/impl/SpigotImplementation.java
+++ b/platform/spigot/src/main/java/com/tcoded/folialib/impl/SpigotImplementation.java
@@ -8,7 +8,7 @@ import com.tcoded.folialib.wrapper.task.WrappedTask;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
@@ -277,7 +277,6 @@ public class SpigotImplementation implements ServerImplementation {
 
     /**
      * Internal util to get a player regardless of the calling thread
-     *
      * @param playerSupplier The supplier to get the player
      * @return Player or null if not found
      */
@@ -301,9 +300,22 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause) {
+    public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, TeleportCause cause) {
         CompletableFuture<Boolean> future = new CompletableFuture<>();
-        this.runAtEntity(entity, (task) -> future.complete(entity.teleport(location, cause)));
+
+        this.runAtEntity(entity, (task) -> {
+            if (entity.isValid()) {
+                if (entity instanceof Player && !((Player) entity).isOnline()) {
+                    future.complete(false);
+                } else {
+                    entity.teleport(location, cause);
+                    future.complete(true);
+                }
+            } else {
+                future.complete(false);
+            }
+        });
+
         return future;
     }
 
@@ -312,7 +324,7 @@ public class SpigotImplementation implements ServerImplementation {
         if (!(nativeTask instanceof BukkitTask)) {
             throw new IllegalArgumentException("The nativeTask provided must be a BukkitTask. Got: " + nativeTask.getClass().getName() + " instead.");
         }
-
+        
         return new WrappedBukkitTask((BukkitTask) nativeTask);
     }
 }

--- a/platform/spigot/src/main/java/com/tcoded/folialib/impl/SpigotImplementation.java
+++ b/platform/spigot/src/main/java/com/tcoded/folialib/impl/SpigotImplementation.java
@@ -3,11 +3,12 @@ package com.tcoded.folialib.impl;
 import com.tcoded.folialib.FoliaLib;
 import com.tcoded.folialib.enums.EntityTaskResult;
 import com.tcoded.folialib.util.TimeConverter;
-import com.tcoded.folialib.wrapper.task.WrappedTask;
 import com.tcoded.folialib.wrapper.task.WrappedBukkitTask;
+import com.tcoded.folialib.wrapper.task.WrappedTask;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
@@ -276,6 +277,7 @@ public class SpigotImplementation implements ServerImplementation {
 
     /**
      * Internal util to get a player regardless of the calling thread
+     *
      * @param playerSupplier The supplier to get the player
      * @return Player or null if not found
      */
@@ -299,18 +301,9 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Boolean> teleportAsync(Player player, Location location) {
+    public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause) {
         CompletableFuture<Boolean> future = new CompletableFuture<>();
-
-        this.runAtEntity(player, (task) -> {
-            if (player.isValid() && player.isOnline()) {
-                player.teleport(location);
-                future.complete(true);
-            } else {
-                future.complete(false);
-            }
-        });
-
+        this.runAtEntity(entity, (task) -> future.complete(entity.teleport(location, cause)));
         return future;
     }
 
@@ -319,7 +312,7 @@ public class SpigotImplementation implements ServerImplementation {
         if (!(nativeTask instanceof BukkitTask)) {
             throw new IllegalArgumentException("The nativeTask provided must be a BukkitTask. Got: " + nativeTask.getClass().getName() + " instead.");
         }
-        
+
         return new WrappedBukkitTask((BukkitTask) nativeTask);
     }
 }


### PR DESCRIPTION
### I have changed the method:
 `public CompletableFuture<Boolean> teleportAsync(Player player, Location location)`
### Now, it is:
 ` public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause) `

### Why?
Because `Player.teleport()` is actually `Entity.teleport()`

And There is a argment named `PlayerTeleportEvent.TeleportCause`

### Another Change

**This part of code seems meaningless.**

```Java
this.runAtEntity(player, (task) -> {
    if (player.isValid() && player.isOnline()) {
        player.teleport(location);
        future.complete(true);
    } else {
        future.complete(false);
    }
});
```
**And it can be replaced with:**

```Java
this.runAtEntity(entity, (task) -> future.complete(entity.teleport(location, cause)));
```

**So I did it.**

*Hope to adopt, thank you, it's really useful and helpful to me*
