### PR TITLE
Chain

### DIFF
--- a/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
+++ b/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
@@ -56,7 +56,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @param delay Delay before execution in ticks
      */
-    void runLater(@NotNull Consumer<WrappedTask> consumer, long delay);
+    CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay);
 
     /**
      * Folia: Synced with the server daylight cycle tick
@@ -77,7 +77,7 @@ public interface ServerImplementation {
      * @param delay Delay before execution
      * @param unit Time unit
      */
-    void runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
+    CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
     /**
      * Folia: Async
@@ -96,7 +96,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @param delay Delay before execution in ticks
      */
-    void runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay);
+    CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay);
 
     /**
      * Folia: Async
@@ -117,7 +117,7 @@ public interface ServerImplementation {
      * @param delay Delay before execution
      * @param unit Time unit
      */
-    void runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
+    CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
     // ----- Global Timers -----
 
@@ -241,7 +241,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @param delay Delay before execution in ticks
      */
-    void runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay);
+    CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay);
 
     /**
      * Folia: Synced with the tick of the region of the chunk of the location
@@ -264,7 +264,7 @@ public interface ServerImplementation {
      * @param delay Delay before execution
      * @param unit Time unit
      */
-    void runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
+    CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
     /**
      * Folia: Synced with the tick of the region of the chunk of the location
@@ -368,7 +368,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @param delay Delay before execution in ticks
      */
-    void runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay);
+    CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay);
 
     /**
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
@@ -379,7 +379,7 @@ public interface ServerImplementation {
      * @param fallback Fallback task to run when the entity is removed
      * @param delay Delay before execution in ticks
      */
-    void runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback, long delay);
+    CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback, long delay);
 
     /**
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
@@ -402,7 +402,7 @@ public interface ServerImplementation {
      * @param delay Delay before execution
      * @param unit Time unit
      */
-    void runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
+    CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
     /**
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)

--- a/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
+++ b/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
@@ -55,6 +55,7 @@ public interface ServerImplementation {
      * Spigot: Synced with the server main thread
      * @param consumer Task to run
      * @param delay Delay before execution in ticks
+     * @return Future when the task is completed
      */
     CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay);
 
@@ -76,6 +77,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @param delay Delay before execution
      * @param unit Time unit
+     * @return Future when the task is completed
      */
     CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
@@ -95,6 +97,7 @@ public interface ServerImplementation {
      * Spigot: Async
      * @param consumer Task to run
      * @param delay Delay before execution in ticks
+     * @return Future when the task is completed
      */
     CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay);
 
@@ -116,6 +119,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @param delay Delay before execution
      * @param unit Time unit
+     * @return Future when the task is completed
      */
     CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
@@ -240,6 +244,7 @@ public interface ServerImplementation {
      * @param location Location to run the task at
      * @param consumer Task to run
      * @param delay Delay before execution in ticks
+     * @return Future when the task is completed
      */
     CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay);
 
@@ -263,6 +268,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @param delay Delay before execution
      * @param unit Time unit
+     * @return Future when the task is completed
      */
     CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
@@ -367,6 +373,7 @@ public interface ServerImplementation {
      * @param entity Entity to run the task at
      * @param consumer Task to run
      * @param delay Delay before execution in ticks
+     * @return Future when the task is completed
      */
     CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay);
 
@@ -378,6 +385,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @param fallback Fallback task to run when the entity is removed
      * @param delay Delay before execution in ticks
+     * @return Future when the task is completed
      */
     CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback, long delay);
 
@@ -401,6 +409,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @param delay Delay before execution
      * @param unit Time unit
+     * @return Future when the task is completed
      */
     CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 

--- a/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
+++ b/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
@@ -28,7 +28,7 @@ public interface ServerImplementation {
      * Paper: Synced with the server main thread
      * Spigot: Synced with the server main thread
      * @param consumer Task to run
-     * @return Future when the task is completed
+     * @return Future when the task is completed, run on the same thread as the task
      */
     @NotNull CompletableFuture<Void> runNextTick(@NotNull Consumer<WrappedTask> consumer);
 
@@ -37,7 +37,7 @@ public interface ServerImplementation {
      * Paper: Async
      * Spigot: Async
      * @param consumer Task to run
-     * @return Future when the task is completed
+     * @return Future when the task is completed, run on the same thread as the task
      */
     @NotNull CompletableFuture<Void> runAsync(@NotNull Consumer<WrappedTask> consumer);
 
@@ -59,7 +59,7 @@ public interface ServerImplementation {
      * Spigot: Synced with the server main thread
      * @param consumer Task to run
      * @param delay Delay before execution in ticks
-     * @return Future when the task is completed
+     * @return Future when the task is completed, run on the same thread as the task
      */
     @NotNull CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay);
 
@@ -81,7 +81,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @param delay Delay before execution
      * @param unit Time unit
-     * @return Future when the task is completed
+     * @return Future when the task is completed, run on the same thread as the task
      */
     @NotNull CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
@@ -101,7 +101,7 @@ public interface ServerImplementation {
      * Spigot: Async
      * @param consumer Task to run
      * @param delay Delay before execution in ticks
-     * @return Future when the task is completed
+     * @return Future when the task is completed, run on the same thread as the task
      */
     @NotNull CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay);
 
@@ -123,7 +123,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @param delay Delay before execution
      * @param unit Time unit
-     * @return Future when the task is completed
+     * @return Future when the task is completed, run on the same thread as the task
      */
     @NotNull CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
@@ -226,7 +226,7 @@ public interface ServerImplementation {
      * Spigot: Synced with the server main thread
      * @param location Location to run the task at
      * @param consumer Task to run
-     * @return Future when the task is completed
+     * @return Future when the task is completed, run on the same thread as the task
      */
     @NotNull CompletableFuture<Void> runAtLocation(Location location, @NotNull Consumer<WrappedTask> consumer);
 
@@ -248,7 +248,7 @@ public interface ServerImplementation {
      * @param location Location to run the task at
      * @param consumer Task to run
      * @param delay Delay before execution in ticks
-     * @return Future when the task is completed
+     * @return Future when the task is completed, run on the same thread as the task
      */
     @NotNull CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay);
 
@@ -272,7 +272,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @param delay Delay before execution
      * @param unit Time unit
-     * @return Future when the task is completed
+     * @return Future when the task is completed, run on the same thread as the task
      */
     @NotNull CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
@@ -333,7 +333,7 @@ public interface ServerImplementation {
      * Spigot: Synced with the server main thread
      * @param entity Entity to run the task at
      * @param consumer Task to run
-     * @return Future when the task is completed
+     * @return Future when the task is completed, run on the same thread as the task
      */
     @NotNull CompletableFuture<EntityTaskResult> runAtEntity(Entity entity, @NotNull Consumer<WrappedTask> consumer);
 
@@ -343,7 +343,7 @@ public interface ServerImplementation {
      * Spigot: Synced with the server main thread
      * @param entity Entity to run the task at
      * @param consumer Task to run
-     * @return Future when the task is completed
+     * @return Future when the task is completed, run on the same thread as the task
      */
     @NotNull CompletableFuture<EntityTaskResult> runAtEntityWithFallback(Entity entity, @NotNull Consumer<WrappedTask> consumer, @Nullable Runnable fallback);
 
@@ -377,7 +377,7 @@ public interface ServerImplementation {
      * @param entity Entity to run the task at
      * @param consumer Task to run
      * @param delay Delay before execution in ticks
-     * @return Future when the task is completed
+     * @return Future when the task is completed, run on the same thread as the task
      */
     @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay);
 
@@ -389,7 +389,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @param fallback Fallback task to run when the entity is removed
      * @param delay Delay before execution in ticks
-     * @return Future when the task is completed
+     * @return Future when the task is completed, run on the same thread as the task
      */
     @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback, long delay);
 
@@ -413,7 +413,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @param delay Delay before execution
      * @param unit Time unit
-     * @return Future when the task is completed
+     * @return Future when the task is completed, run on the same thread as the task
      */
     @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 

--- a/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
+++ b/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
@@ -26,7 +26,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @return Future when the task is completed
      */
-    CompletableFuture<Void> runNextTick(@NotNull Consumer<WrappedTask> consumer);
+    @NotNull CompletableFuture<Void> runNextTick(@NotNull Consumer<WrappedTask> consumer);
 
     /**
      * Folia: Async
@@ -35,7 +35,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @return Future when the task is completed
      */
-    CompletableFuture<Void> runAsync(@NotNull Consumer<WrappedTask> consumer);
+    @NotNull CompletableFuture<Void> runAsync(@NotNull Consumer<WrappedTask> consumer);
 
     // ----- Run Later -----
 
@@ -57,7 +57,7 @@ public interface ServerImplementation {
      * @param delay Delay before execution in ticks
      * @return Future when the task is completed
      */
-    CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay);
+    @NotNull CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay);
 
     /**
      * Folia: Synced with the server daylight cycle tick
@@ -79,7 +79,7 @@ public interface ServerImplementation {
      * @param unit Time unit
      * @return Future when the task is completed
      */
-    CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
+    @NotNull CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
     /**
      * Folia: Async
@@ -99,7 +99,7 @@ public interface ServerImplementation {
      * @param delay Delay before execution in ticks
      * @return Future when the task is completed
      */
-    CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay);
+    @NotNull CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay);
 
     /**
      * Folia: Async
@@ -121,7 +121,7 @@ public interface ServerImplementation {
      * @param unit Time unit
      * @return Future when the task is completed
      */
-    CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
+    @NotNull CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
     // ----- Global Timers -----
 
@@ -224,7 +224,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @return Future when the task is completed
      */
-    CompletableFuture<Void> runAtLocation(Location location, @NotNull Consumer<WrappedTask> consumer);
+    @NotNull CompletableFuture<Void> runAtLocation(Location location, @NotNull Consumer<WrappedTask> consumer);
 
     /**
      * Folia: Synced with the tick of the region of the chunk of the location
@@ -246,7 +246,7 @@ public interface ServerImplementation {
      * @param delay Delay before execution in ticks
      * @return Future when the task is completed
      */
-    CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay);
+    @NotNull CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay);
 
     /**
      * Folia: Synced with the tick of the region of the chunk of the location
@@ -270,7 +270,7 @@ public interface ServerImplementation {
      * @param unit Time unit
      * @return Future when the task is completed
      */
-    CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
+    @NotNull CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
     /**
      * Folia: Synced with the tick of the region of the chunk of the location
@@ -331,7 +331,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @return Future when the task is completed
      */
-    CompletableFuture<EntityTaskResult> runAtEntity(Entity entity, @NotNull Consumer<WrappedTask> consumer);
+    @NotNull CompletableFuture<EntityTaskResult> runAtEntity(Entity entity, @NotNull Consumer<WrappedTask> consumer);
 
     /**
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
@@ -341,7 +341,7 @@ public interface ServerImplementation {
      * @param consumer Task to run
      * @return Future when the task is completed
      */
-    CompletableFuture<EntityTaskResult> runAtEntityWithFallback(Entity entity, @NotNull Consumer<WrappedTask> consumer, @Nullable Runnable fallback);
+    @NotNull CompletableFuture<EntityTaskResult> runAtEntityWithFallback(Entity entity, @NotNull Consumer<WrappedTask> consumer, @Nullable Runnable fallback);
 
     /**
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
@@ -375,7 +375,7 @@ public interface ServerImplementation {
      * @param delay Delay before execution in ticks
      * @return Future when the task is completed
      */
-    CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay);
+    @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay);
 
     /**
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
@@ -387,7 +387,7 @@ public interface ServerImplementation {
      * @param delay Delay before execution in ticks
      * @return Future when the task is completed
      */
-    CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback, long delay);
+    @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback, long delay);
 
     /**
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)
@@ -411,7 +411,7 @@ public interface ServerImplementation {
      * @param unit Time unit
      * @return Future when the task is completed
      */
-    CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
+    @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit);
 
     /**
      * Folia: Synced with the tick of the region of the entity (even if the entity moves)

--- a/platform/folia/src/main/java/com/tcoded/folialib/impl/FoliaImplementation.java
+++ b/platform/folia/src/main/java/com/tcoded/folialib/impl/FoliaImplementation.java
@@ -41,7 +41,7 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public CompletableFuture<Void> runNextTick(@NotNull Consumer<WrappedTask> consumer) {
+    public @NotNull CompletableFuture<Void> runNextTick(@NotNull Consumer<WrappedTask> consumer) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         this.globalRegionScheduler.run(plugin, task -> {
@@ -53,7 +53,7 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public CompletableFuture<Void> runAsync(@NotNull Consumer<WrappedTask> consumer) {
+    public @NotNull CompletableFuture<Void> runAsync(@NotNull Consumer<WrappedTask> consumer) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         this.asyncScheduler.runNow(plugin, task -> {
@@ -74,7 +74,7 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay) {
+    public @NotNull CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         if (delay <= 0) {
@@ -95,7 +95,7 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+    public @NotNull CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         return this.runLater(consumer, TimeConverter.toTicks(delay, unit));
     }
 
@@ -105,7 +105,7 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay) {
+    public @NotNull CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay) {
         return this.runLaterAsync(consumer, TimeConverter.toMillis(delay), TimeUnit.MILLISECONDS);
     }
 
@@ -117,7 +117,7 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+    public @NotNull CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         this.asyncScheduler.runDelayed(plugin, task -> {
@@ -193,7 +193,7 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public CompletableFuture<Void> runAtLocation(Location location, @NotNull Consumer<WrappedTask> consumer) {
+    public @NotNull CompletableFuture<Void> runAtLocation(Location location, @NotNull Consumer<WrappedTask> consumer) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         this.plugin.getServer().getRegionScheduler().run(plugin, location, task -> {
@@ -216,7 +216,7 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay) {
+    public @NotNull CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         if (delay <= 0) {
@@ -237,7 +237,7 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+    public @NotNull CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         return this.runAtLocationLater(location, consumer, TimeConverter.toTicks(delay, unit));
     }
 
@@ -280,7 +280,7 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public CompletableFuture<EntityTaskResult> runAtEntity(Entity entity, @NotNull Consumer<WrappedTask> consumer) {
+    public @NotNull CompletableFuture<EntityTaskResult> runAtEntity(Entity entity, @NotNull Consumer<WrappedTask> consumer) {
         CompletableFuture<EntityTaskResult> future = new CompletableFuture<>();
 
         ScheduledTask scheduledTask = entity.getScheduler().run(this.plugin, task -> {
@@ -296,7 +296,7 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public CompletableFuture<EntityTaskResult> runAtEntityWithFallback(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback) {
+    public @NotNull CompletableFuture<EntityTaskResult> runAtEntityWithFallback(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback) {
         CompletableFuture<EntityTaskResult> future = new CompletableFuture<>();
 
         ScheduledTask scheduledTask = entity.getScheduler().run(this.plugin, task -> {
@@ -329,12 +329,12 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay) {
+    public @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay) {
         return this.runAtEntityLater(entity, consumer, null, delay);
     }
 
 	@Override
-    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback, long delay) {
+    public @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback, long delay) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         // Wrap the fallback so we can complete the future
@@ -364,7 +364,7 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+    public @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         return this.runAtEntityLater(entity, consumer, TimeConverter.toTicks(delay, unit));
     }
 

--- a/platform/folia/src/main/java/com/tcoded/folialib/impl/FoliaImplementation.java
+++ b/platform/folia/src/main/java/com/tcoded/folialib/impl/FoliaImplementation.java
@@ -74,12 +74,19 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public void runLater(@NotNull Consumer<WrappedTask> consumer, long delay) {
+    public CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
             delay = 1;
         }
-        this.globalRegionScheduler.runDelayed(plugin, task -> consumer.accept(this.wrapTask(task)), delay);
+        this.globalRegionScheduler.runDelayed(plugin, task -> {
+            consumer.accept(this.wrapTask(task));
+            future.complete(null);
+        }, delay);
+
+        return future;
     }
 
 	@Override
@@ -88,8 +95,8 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public void runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
-        this.runLater(consumer, TimeConverter.toTicks(delay, unit));
+    public CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+        return this.runLater(consumer, TimeConverter.toTicks(delay, unit));
     }
 
 	@Override
@@ -98,8 +105,8 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public void runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay) {
-        this.runLaterAsync(consumer, TimeConverter.toMillis(delay), TimeUnit.MILLISECONDS);
+    public CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay) {
+        return this.runLaterAsync(consumer, TimeConverter.toMillis(delay), TimeUnit.MILLISECONDS);
     }
 
 	@Override
@@ -110,8 +117,15 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public void runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
-        this.asyncScheduler.runDelayed(plugin, task -> consumer.accept(this.wrapTask(task)), delay, unit);
+    public CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        this.asyncScheduler.runDelayed(plugin, task -> {
+            consumer.accept(this.wrapTask(task));
+            future.complete(null);
+        }, delay, unit);
+
+        return future;
     }
 
 	@Override
@@ -202,12 +216,19 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public void runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay) {
+    public CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
             delay = 1;
         }
-        this.plugin.getServer().getRegionScheduler().runDelayed(plugin, location, task -> consumer.accept(this.wrapTask(task)), delay);
+        this.plugin.getServer().getRegionScheduler().runDelayed(plugin, location, task -> {
+            consumer.accept(this.wrapTask(task));
+            future.complete(null);
+        }, delay);
+
+        return future;
     }
 
 	@Override
@@ -216,8 +237,8 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public void runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
-        this.runAtLocationLater(location, consumer, TimeConverter.toTicks(delay, unit));
+    public CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+        return this.runAtLocationLater(location, consumer, TimeConverter.toTicks(delay, unit));
     }
 
 	@Override
@@ -308,17 +329,33 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public void runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay) {
-        this.runAtEntityLater(entity, consumer, null, delay);
+    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay) {
+        return this.runAtEntityLater(entity, consumer, null, delay);
     }
 
 	@Override
-    public void runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback, long delay) {
+    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback, long delay) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        // Wrap the fallback so we can complete the future
+        if (fallback != null) {
+            final Runnable finalFallback = fallback;
+            fallback = () -> {
+                finalFallback.run();
+                future.complete(null);
+            };
+        }
+
         if (delay <= 0) {
             InvalidTickDelayNotifier.notifyOnce(plugin.getLogger(), delay);
             delay = 1;
         }
-        entity.getScheduler().runDelayed(plugin, task -> consumer.accept(this.wrapTask(task)), fallback, delay);
+        entity.getScheduler().runDelayed(plugin, task -> {
+            consumer.accept(this.wrapTask(task));
+            future.complete(null);
+        }, fallback, delay);
+
+        return future;
     }
 
 	@Override
@@ -327,8 +364,8 @@ public class FoliaImplementation implements ServerImplementation {
     }
 
 	@Override
-    public void runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
-        this.runAtEntityLater(entity, consumer, TimeConverter.toTicks(delay, unit));
+    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+        return this.runAtEntityLater(entity, consumer, TimeConverter.toTicks(delay, unit));
     }
 
 	@Override

--- a/platform/legacy-spigot/src/main/java/com/tcoded/folialib/impl/LegacySpigotImplementation.java
+++ b/platform/legacy-spigot/src/main/java/com/tcoded/folialib/impl/LegacySpigotImplementation.java
@@ -68,12 +68,16 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runLater(@NotNull Consumer<WrappedTask> consumer, long delay) {
+    public CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
         WrappedTask[] taskReference = new WrappedTask[1];
 
         taskReference[0] = this.wrapTask(this.scheduler.runTaskLater(plugin, () -> {
             consumer.accept(taskReference[0]);
+            future.complete(null);
         }, delay));
+
+        return future;
     }
 
     @Override
@@ -82,8 +86,8 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
-        this.runLater(consumer, TimeConverter.toTicks(delay, unit));
+    public CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+        return this.runLater(consumer, TimeConverter.toTicks(delay, unit));
     }
 
     @Override
@@ -92,12 +96,16 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay) {
+    public CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
         WrappedTask[] taskReference = new WrappedTask[1];
 
         taskReference[0] = this.wrapTask(this.scheduler.runTaskLaterAsynchronously(plugin, () -> {
             consumer.accept(taskReference[0]);
+            future.complete(null);
         }, delay));
+
+        return future;
     }
 
     @Override
@@ -106,8 +114,8 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
-        this.runLaterAsync(consumer, TimeConverter.toTicks(delay, unit));
+    public CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+        return this.runLaterAsync(consumer, TimeConverter.toTicks(delay, unit));
     }
 
     @Override
@@ -169,12 +177,16 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay) {
+    public CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
         WrappedTask[] taskReference = new WrappedTask[1];
 
         taskReference[0] = this.wrapTask(this.scheduler.runTaskLater(plugin, () -> {
             consumer.accept(taskReference[0]);
+            future.complete(null);
         }, delay));
+
+        return future;
     }
 
     @Override
@@ -183,8 +195,8 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
-        this.runAtLocationLater(location, consumer, TimeConverter.toTicks(delay, unit));
+    public CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+        return this.runAtLocationLater(location, consumer, TimeConverter.toTicks(delay, unit));
     }
 
     @Override
@@ -257,20 +269,28 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay) {
-        this.runAtEntityLater(entity, consumer, null, delay);
+    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay) {
+        return this.runAtEntityLater(entity, consumer, null, delay);
     }
 
     @Override
-    public void runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback, long delay) {
+    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback, long delay) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
         if (!entity.isValid()) {
-            if (fallback != null) fallback.run();
+            if (fallback != null) {
+                fallback.run();
+                future.complete(null);
+            }
         }
         WrappedTask[] taskReference = new WrappedTask[1];
 
         taskReference[0] = this.wrapTask(this.scheduler.runTaskLater(plugin, () -> {
             consumer.accept(taskReference[0]);
+            future.complete(null);
         }, delay));
+
+        return future;
     }
 
     @Override
@@ -279,8 +299,8 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
-        this.runAtEntityLater(entity, consumer, TimeConverter.toTicks(delay, unit));
+    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+        return this.runAtEntityLater(entity, consumer, TimeConverter.toTicks(delay, unit));
     }
 
     @Override

--- a/platform/legacy-spigot/src/main/java/com/tcoded/folialib/impl/LegacySpigotImplementation.java
+++ b/platform/legacy-spigot/src/main/java/com/tcoded/folialib/impl/LegacySpigotImplementation.java
@@ -37,7 +37,7 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runNextTick(@NotNull Consumer<WrappedTask> consumer) {
+    public @NotNull CompletableFuture<Void> runNextTick(@NotNull Consumer<WrappedTask> consumer) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         WrappedTask[] taskReference = new WrappedTask[1];
 
@@ -50,7 +50,7 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runAsync(@NotNull Consumer<WrappedTask> consumer) {
+    public @NotNull CompletableFuture<Void> runAsync(@NotNull Consumer<WrappedTask> consumer) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         WrappedTask[] taskReference = new WrappedTask[1];
 
@@ -68,7 +68,7 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay) {
+    public @NotNull CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         WrappedTask[] taskReference = new WrappedTask[1];
 
@@ -86,7 +86,7 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+    public @NotNull CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         return this.runLater(consumer, TimeConverter.toTicks(delay, unit));
     }
 
@@ -96,7 +96,7 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay) {
+    public @NotNull CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         WrappedTask[] taskReference = new WrappedTask[1];
 
@@ -114,7 +114,7 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+    public @NotNull CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         return this.runLaterAsync(consumer, TimeConverter.toTicks(delay, unit));
     }
 
@@ -167,7 +167,7 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runAtLocation(Location location, @NotNull Consumer<WrappedTask> consumer) {
+    public @NotNull CompletableFuture<Void> runAtLocation(Location location, @NotNull Consumer<WrappedTask> consumer) {
         return this.runNextTick(consumer);
     }
 
@@ -177,7 +177,7 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay) {
+    public @NotNull CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         WrappedTask[] taskReference = new WrappedTask[1];
 
@@ -195,7 +195,7 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+    public @NotNull CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         return this.runAtLocationLater(location, consumer, TimeConverter.toTicks(delay, unit));
     }
 
@@ -224,7 +224,7 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<EntityTaskResult> runAtEntity(Entity entity, @NotNull Consumer<WrappedTask> consumer) {
+    public @NotNull CompletableFuture<EntityTaskResult> runAtEntity(Entity entity, @NotNull Consumer<WrappedTask> consumer) {
         CompletableFuture<EntityTaskResult> future = new CompletableFuture<>();
         WrappedTask[] taskReference = new WrappedTask[1];
 
@@ -237,7 +237,7 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<EntityTaskResult> runAtEntityWithFallback(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback) {
+    public @NotNull CompletableFuture<EntityTaskResult> runAtEntityWithFallback(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback) {
         CompletableFuture<EntityTaskResult> future = new CompletableFuture<>();
         WrappedTask[] taskReference = new WrappedTask[1];
 
@@ -269,12 +269,12 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay) {
+    public @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay) {
         return this.runAtEntityLater(entity, consumer, null, delay);
     }
 
     @Override
-    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback, long delay) {
+    public @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback, long delay) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         if (!entity.isValid()) {
@@ -299,7 +299,7 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+    public @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         return this.runAtEntityLater(entity, consumer, TimeConverter.toTicks(delay, unit));
     }
 

--- a/platform/spigot/src/main/java/com/tcoded/folialib/impl/SpigotImplementation.java
+++ b/platform/spigot/src/main/java/com/tcoded/folialib/impl/SpigotImplementation.java
@@ -35,7 +35,7 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runNextTick(@NotNull Consumer<WrappedTask> consumer) {
+    public @NotNull CompletableFuture<Void> runNextTick(@NotNull Consumer<WrappedTask> consumer) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         this.scheduler.runTask(plugin, (task) -> {
@@ -47,7 +47,7 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runAsync(@NotNull Consumer<WrappedTask> consumer) {
+    public @NotNull CompletableFuture<Void> runAsync(@NotNull Consumer<WrappedTask> consumer) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         this.scheduler.runTaskAsynchronously(plugin, (task) -> {
@@ -64,7 +64,7 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay) {
+    public @NotNull CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         this.scheduler.runTaskLater(plugin, task -> {
@@ -81,7 +81,7 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+    public @NotNull CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         return this.runLater(consumer, TimeConverter.toTicks(delay, unit));
     }
 
@@ -91,7 +91,7 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay) {
+    public @NotNull CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         this.scheduler.runTaskLaterAsynchronously(plugin, task -> {
@@ -108,7 +108,7 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+    public @NotNull CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         return this.runLaterAsync(consumer, TimeConverter.toTicks(delay, unit));
     }
 
@@ -153,7 +153,7 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runAtLocation(Location location, @NotNull Consumer<WrappedTask> consumer) {
+    public @NotNull CompletableFuture<Void> runAtLocation(Location location, @NotNull Consumer<WrappedTask> consumer) {
         return this.runNextTick(consumer);
     }
 
@@ -163,7 +163,7 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay) {
+    public @NotNull CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay) {
         return this.runLater(consumer, delay);
     }
 
@@ -173,7 +173,7 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+    public @NotNull CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         return this.runAtLocationLater(location, consumer, TimeConverter.toTicks(delay, unit));
     }
 
@@ -198,7 +198,7 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<EntityTaskResult> runAtEntity(Entity entity, @NotNull Consumer<WrappedTask> consumer) {
+    public @NotNull CompletableFuture<EntityTaskResult> runAtEntity(Entity entity, @NotNull Consumer<WrappedTask> consumer) {
         CompletableFuture<EntityTaskResult> future = new CompletableFuture<>();
 
         this.scheduler.runTask(plugin, (task) -> {
@@ -210,7 +210,7 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<EntityTaskResult> runAtEntityWithFallback(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback) {
+    public @NotNull CompletableFuture<EntityTaskResult> runAtEntityWithFallback(Entity entity, @NotNull Consumer<WrappedTask> consumer, Runnable fallback) {
         CompletableFuture<EntityTaskResult> future = new CompletableFuture<>();
 
         this.scheduler.runTask(plugin, (task) -> {
@@ -241,12 +241,12 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay) {
+    public @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay) {
         return this.runAtEntityLater(entity, consumer, null, delay);
     }
 
     @Override
-    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, @Nullable Runnable fallback, long delay) {
+    public @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, @Nullable Runnable fallback, long delay) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         if (!entity.isValid()) {
@@ -271,7 +271,7 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+    public @NotNull CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
         return this.runAtEntityLater(entity, consumer, TimeConverter.toTicks(delay, unit));
     }
 

--- a/platform/spigot/src/main/java/com/tcoded/folialib/impl/SpigotImplementation.java
+++ b/platform/spigot/src/main/java/com/tcoded/folialib/impl/SpigotImplementation.java
@@ -64,8 +64,15 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runLater(@NotNull Consumer<WrappedTask> consumer, long delay) {
-        this.scheduler.runTaskLater(plugin, task -> consumer.accept(this.wrapTask(task)), delay);
+    public CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        this.scheduler.runTaskLater(plugin, task -> {
+            consumer.accept(this.wrapTask(task));
+            future.complete(null);
+        }, delay);
+
+        return future;
     }
 
     @Override
@@ -74,8 +81,8 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
-        this.runLater(consumer, TimeConverter.toTicks(delay, unit));
+    public CompletableFuture<Void> runLater(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+        return this.runLater(consumer, TimeConverter.toTicks(delay, unit));
     }
 
     @Override
@@ -84,8 +91,15 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay) {
-        this.scheduler.runTaskLaterAsynchronously(plugin, task -> consumer.accept(this.wrapTask(task)), delay);
+    public CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        this.scheduler.runTaskLaterAsynchronously(plugin, task -> {
+            consumer.accept(this.wrapTask(task));
+            future.complete(null);
+        }, delay);
+
+        return future;
     }
 
     @Override
@@ -94,8 +108,8 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
-        this.runLaterAsync(consumer, TimeConverter.toTicks(delay, unit));
+    public CompletableFuture<Void> runLaterAsync(@NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+        return this.runLaterAsync(consumer, TimeConverter.toTicks(delay, unit));
     }
 
     @Override
@@ -149,8 +163,8 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay) {
-        this.runLater(consumer, delay);
+    public CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay) {
+        return this.runLater(consumer, delay);
     }
 
     @Override
@@ -159,8 +173,8 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
-        this.runAtLocationLater(location, consumer, TimeConverter.toTicks(delay, unit));
+    public CompletableFuture<Void> runAtLocationLater(Location location, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+        return this.runAtLocationLater(location, consumer, TimeConverter.toTicks(delay, unit));
     }
 
     @Override
@@ -227,16 +241,28 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay) {
-        this.runAtEntityLater(entity, consumer, null, delay);
+    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay) {
+        return this.runAtEntityLater(entity, consumer, null, delay);
     }
 
     @Override
-    public void runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, @Nullable Runnable fallback, long delay) {
+    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, @Nullable Runnable fallback, long delay) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
         if (!entity.isValid()) {
-            if (fallback != null) fallback.run();
+            if (fallback != null) {
+                fallback.run();
+                future.complete(null);
+            }
         }
-        else this.runAtEntityLater(entity, consumer, delay);
+        else {
+            this.scheduler.runTaskLater(plugin, task -> {
+                consumer.accept(this.wrapTask(task));
+                future.complete(null);
+            }, delay);
+        }
+
+        return future;
     }
 
     @Override
@@ -245,8 +271,8 @@ public class SpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public void runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
-        this.runAtEntityLater(entity, consumer, TimeConverter.toTicks(delay, unit));
+    public CompletableFuture<Void> runAtEntityLater(Entity entity, @NotNull Consumer<WrappedTask> consumer, long delay, TimeUnit unit) {
+        return this.runAtEntityLater(entity, consumer, TimeConverter.toTicks(delay, unit));
     }
 
     @Override


### PR DESCRIPTION
Often, people want to add a callback for after a task is completed. This is done often enough that there are [libs](https://www.spigotmc.org/threads/taskchain-proper-async-operations-and-more.190077/). Unfortunately, with all of the new methods for Folia support, all of these libraries are useless for folia. I noticed that you already have some support for this:
  * https://github.com/TechnicallyCoded/FoliaLib/blob/main/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java#L29
  * https://github.com/TechnicallyCoded/FoliaLib/blob/main/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java#L38
  * https://github.com/TechnicallyCoded/FoliaLib/blob/main/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java#L223
  * https://github.com/TechnicallyCoded/FoliaLib/blob/main/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java#L328
  * https://github.com/TechnicallyCoded/FoliaLib/blob/main/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java#L338

But we don't have those future instances on the `runLater` methods. This PR adds those methods. Quick notes:
1. I did not add futures for `runTimer` methods, because I figured it didn't make much sense. But I am open to adding that to this PR if you'd like.
2. In my edits, I found [a recursion error](https://github.com/CJCrafter/FoliaLib/commit/43c1a70b1ea01e4e75b3618f2ef973ca2ef13f1a#diff-d076a5dabc1c6a4d955a7677f237479ba2d0ad07b3c94ba4962aed1f3ec30a2cL239) that must've slipped through... You have methods just calling eachother
3. I am requesting to merge this into the `dev` branch, since it seems you prefer PRs to go there.

Thanks very much!

Fixes #14 
