### PR TITLE
Thread check

### DIFF
--- a/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
+++ b/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
@@ -36,9 +36,7 @@ public interface ServerImplementation {
      * @param location Specified location, must have a non-null world
      * @return true if the current thread is ticking the region that owns the chunk at the specified location
      */
-    default boolean isOwnedByCurrentRegion(@NotNull Location location) {
-        return Bukkit.isPrimaryThread();
-    }
+    boolean isOwnedByCurrentRegion(@NotNull Location location);
 
     /**
      * Folia: Returns whether the current thread is ticking a region and that
@@ -55,9 +53,7 @@ public interface ServerImplementation {
      * @param squareRadiusChunks Specified square radius. Must be >= 0. Note that this parameter is not a squared radius, but rather a Chebyshev Distance
      * @return true if the current thread is ticking the region that owns the chunks centered at the specified location within the specified square radius
      */
-    default boolean isOwnedByCurrentRegion(@NotNull Location location, int squareRadiusChunks) {
-        return Bukkit.isPrimaryThread();
-    }
+    boolean isOwnedByCurrentRegion(@NotNull Location location, int squareRadiusChunks);
 
     /**
      * Folia: Returns whether the current thread is ticking a region and that
@@ -68,9 +64,7 @@ public interface ServerImplementation {
      * @param block Specified block position
      * @return true if the current thread is ticking the region that owns the chunk at the specified block position
      */
-    default boolean isOwnedByCurrentRegion(@NotNull Block block) {
-        return Bukkit.isPrimaryThread();
-    }
+    boolean isOwnedByCurrentRegion(@NotNull Block block);
 
     /**
      * Folia: Returns whether the current thread is ticking a region and that
@@ -84,9 +78,7 @@ public interface ServerImplementation {
      * @param chunkZ Specified z-coordinate of the chunk position
      * @return true if the current thread is ticking the region that owns the chunk at the specified world and chunk position
      */
-    default boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ) {
-        return Bukkit.isPrimaryThread();
-    }
+    boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ);
 
     /**
      * Folia: Returns whether the current thread is ticking a region and that
@@ -104,9 +96,7 @@ public interface ServerImplementation {
      * @param squareRadiusChunks Specified square radius. Must be >= 0. Note that this parameter is not a squared radius, but rather a Chebyshev Distance.
      * @return true if the current thread is ticking the region that owns the chunks centered at the specified world and chunk position within the specified square radius
      */
-    default boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ, int squareRadiusChunks) {
-        return Bukkit.isPrimaryThread();
-    }
+    boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ, int squareRadiusChunks);
 
     /**
      * Folia: Returns whether the current thread is ticking a region and that
@@ -120,9 +110,7 @@ public interface ServerImplementation {
      * @param entity Specified entity
      * @return true if the current thread is ticking the region that owns the specified entity
      */
-    default boolean isOwnedByCurrentRegion(@NotNull Entity entity) {
-        return Bukkit.isPrimaryThread();
-    }
+    boolean isOwnedByCurrentRegion(@NotNull Entity entity);
 
     /**
      * Folia: Returns whether the current thread is ticking the global region.
@@ -131,9 +119,7 @@ public interface ServerImplementation {
      *
      * @return true if the current thread is ticking the global region
      */
-    default boolean isGlobalTickThread() {
-        return Bukkit.isPrimaryThread();
-    }
+    boolean isGlobalTickThread();
 
     // ----- Run now -----
 

--- a/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
+++ b/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
@@ -2,7 +2,10 @@ package com.tcoded.folialib.impl;
 
 import com.tcoded.folialib.enums.EntityTaskResult;
 import com.tcoded.folialib.wrapper.task.WrappedTask;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -20,6 +23,117 @@ import java.util.function.Consumer;
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 @Deprecated
 public interface ServerImplementation {
+
+    // ----- Check thread -----
+
+    /**
+     * Folia: Returns whether the current thread is ticking a region and that
+     * the region being ticked owns the chunk at the specified world and block
+     * position as included in the specified location.
+     * Paper: Returns {@link Bukkit#isPrimaryThread()}
+     * Spigot: Returns {@link Bukkit#isPrimaryThread()}
+     *
+     * @param location Specified location, must have a non-null world
+     * @return true if the current thread is ticking the region that owns the chunk at the specified location
+     */
+    default boolean isOwnedByCurrentRegion(@NotNull Location location) {
+        return Bukkit.isPrimaryThread();
+    }
+
+    /**
+     * Folia: Returns whether the current thread is ticking a region and that
+     * the region being ticked owns the chunks centered at the specified world
+     * and block position as included in the specified location within the
+     * specified square radius. Specifically, this function checks that every
+     * chunk with position x in [centerX - radius, centerX + radius] and
+     * position z in [centerZ - radius, centerZ + radius] is owned by the
+     * current ticking region.
+     * Paper: Returns {@link Bukkit#isPrimaryThread()}
+     * Spigot: Returns {@link Bukkit#isPrimaryThread()}
+     *
+     * @param location Specified location, must have a non-null world
+     * @param squareRadiusChunks Specified square radius. Must be >= 0. Note that this parameter is not a squared radius, but rather a Chebyshev Distance
+     * @return true if the current thread is ticking the region that owns the chunks centered at the specified location within the specified square radius
+     */
+    default boolean isOwnedByCurrentRegion(@NotNull Location location, int squareRadiusChunks) {
+        return Bukkit.isPrimaryThread();
+    }
+
+    /**
+     * Folia: Returns whether the current thread is ticking a region and that
+     * the region being ticked owns the chunk at the specified block position.
+     * Paper: Returns {@link Bukkit#isPrimaryThread()}
+     * Spigot: Returns {@link Bukkit#isPrimaryThread()}
+     *
+     * @param block Specified block position
+     * @return true if the current thread is ticking the region that owns the chunk at the specified block position
+     */
+    default boolean isOwnedByCurrentRegion(@NotNull Block block) {
+        return Bukkit.isPrimaryThread();
+    }
+
+    /**
+     * Folia: Returns whether the current thread is ticking a region and that
+     * the region being ticked owns the chunk at the specified world and chunk
+     * position.
+     * Paper: Returns {@link Bukkit#isPrimaryThread()}
+     * Spigot: Returns {@link Bukkit#isPrimaryThread()}
+     *
+     * @param world Specified world
+     * @param chunkX Specified x-coordinate of the chunk position
+     * @param chunkZ Specified z-coordinate of the chunk position
+     * @return true if the current thread is ticking the region that owns the chunk at the specified world and chunk position
+     */
+    default boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ) {
+        return Bukkit.isPrimaryThread();
+    }
+
+    /**
+     * Folia: Returns whether the current thread is ticking a region and that
+     * the region being ticked owns the chunks centered at the specified world
+     * and chunk position within the specified square radius. Specifically,
+     * this function checks that every chunk with position x in [centerX -
+     * radius, centerX + radius] and position z in [centerZ - radius, centerZ +
+     * radius] is owned by the current ticking region.
+     * Paper: Returns {@link Bukkit#isPrimaryThread()}
+     * Spigot: Returns {@link Bukkit#isPrimaryThread()}
+     *
+     * @param world Specified world
+     * @param chunkX Specified x-coordinate of the chunk position
+     * @param chunkZ Specified z-coordinate of the chunk position
+     * @param squareRadiusChunks Specified square radius. Must be >= 0. Note that this parameter is not a squared radius, but rather a Chebyshev Distance.
+     * @return true if the current thread is ticking the region that owns the chunks centered at the specified world and chunk position within the specified square radius
+     */
+    default boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ, int squareRadiusChunks) {
+        return Bukkit.isPrimaryThread();
+    }
+
+    /**
+     * Folia: Returns whether the current thread is ticking a region and that
+     * the region being ticked owns the specified entity. Note that this
+     * function is the only appropriate method of checking for ownership of an
+     * entity, as retrieving the entity's location is undefined unless the
+     * entity is owned by the current region.
+     * Paper: Returns {@link Bukkit#isPrimaryThread()}
+     * Spigot: Returns {@link Bukkit#isPrimaryThread()}
+     *
+     * @param entity Specified entity
+     * @return true if the current thread is ticking the region that owns the specified entity
+     */
+    default boolean isOwnedByCurrentRegion(@NotNull Entity entity) {
+        return Bukkit.isPrimaryThread();
+    }
+
+    /**
+     * Folia: Returns whether the current thread is ticking the global region.
+     * Paper: Returns {@link Bukkit#isPrimaryThread()}
+     * Spigot: Returns {@link Bukkit#isPrimaryThread()}
+     *
+     * @return true if the current thread is ticking the global region
+     */
+    default boolean isGlobalTickThread() {
+        return Bukkit.isPrimaryThread();
+    }
 
     // ----- Run now -----
 

--- a/platform/folia/src/main/java/com/tcoded/folialib/impl/FoliaImplementation.java
+++ b/platform/folia/src/main/java/com/tcoded/folialib/impl/FoliaImplementation.java
@@ -10,7 +10,10 @@ import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
 import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
 import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -40,7 +43,42 @@ public class FoliaImplementation implements SchedulerImpl {
         this.asyncScheduler = plugin.getServer().getAsyncScheduler();
     }
 
-	@Override
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull Location location) {
+        return Bukkit.isOwnedByCurrentRegion(location);
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull Location location, int squareRadiusChunks) {
+        return Bukkit.isOwnedByCurrentRegion(location, squareRadiusChunks);
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull Block block) {
+        return Bukkit.isOwnedByCurrentRegion(block);
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ) {
+        return Bukkit.isOwnedByCurrentRegion(world, chunkX, chunkZ);
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ, int squareRadiusChunks) {
+        return Bukkit.isOwnedByCurrentRegion(world, chunkX, chunkZ, squareRadiusChunks);
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull Entity entity) {
+        return Bukkit.isOwnedByCurrentRegion(entity);
+    }
+
+    @Override
+    public boolean isGlobalTickThread() {
+        return Bukkit.isGlobalTickThread();
+    }
+
+    @Override
     public CompletableFuture<Void> runNextTick(@NotNull Consumer<WrappedTask> consumer) {
         CompletableFuture<Void> future = new CompletableFuture<>();
 

--- a/platform/folia/src/main/java/com/tcoded/folialib/impl/FoliaImplementation.java
+++ b/platform/folia/src/main/java/com/tcoded/folialib/impl/FoliaImplementation.java
@@ -45,37 +45,37 @@ public class FoliaImplementation implements SchedulerImpl {
 
     @Override
     public boolean isOwnedByCurrentRegion(@NotNull Location location) {
-        return Bukkit.isOwnedByCurrentRegion(location);
+        return this.plugin.getServer().isOwnedByCurrentRegion(location);
     }
 
     @Override
     public boolean isOwnedByCurrentRegion(@NotNull Location location, int squareRadiusChunks) {
-        return Bukkit.isOwnedByCurrentRegion(location, squareRadiusChunks);
+        return this.plugin.getServer().isOwnedByCurrentRegion(location, squareRadiusChunks);
     }
 
     @Override
     public boolean isOwnedByCurrentRegion(@NotNull Block block) {
-        return Bukkit.isOwnedByCurrentRegion(block);
+        return this.plugin.getServer().isOwnedByCurrentRegion(block);
     }
 
     @Override
     public boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ) {
-        return Bukkit.isOwnedByCurrentRegion(world, chunkX, chunkZ);
+        return this.plugin.getServer().isOwnedByCurrentRegion(world, chunkX, chunkZ);
     }
 
     @Override
     public boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ, int squareRadiusChunks) {
-        return Bukkit.isOwnedByCurrentRegion(world, chunkX, chunkZ, squareRadiusChunks);
+        return this.plugin.getServer().isOwnedByCurrentRegion(world, chunkX, chunkZ, squareRadiusChunks);
     }
 
     @Override
     public boolean isOwnedByCurrentRegion(@NotNull Entity entity) {
-        return Bukkit.isOwnedByCurrentRegion(entity);
+        return this.plugin.getServer().isOwnedByCurrentRegion(entity);
     }
 
     @Override
     public boolean isGlobalTickThread() {
-        return Bukkit.isGlobalTickThread();
+        return this.plugin.getServer().isGlobalTickThread();
     }
 
     @Override

--- a/platform/legacy-spigot/src/main/java/com/tcoded/folialib/impl/LegacySpigotImplementation.java
+++ b/platform/legacy-spigot/src/main/java/com/tcoded/folialib/impl/LegacySpigotImplementation.java
@@ -8,6 +8,8 @@ import com.tcoded.folialib.wrapper.task.WrappedBukkitTask;
 import com.tcoded.folialib.wrapper.task.WrappedTask;
 import com.tcoded.folialib.wrapper.task.WrappedLegacyBukkitTask;
 import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -34,6 +36,41 @@ public class LegacySpigotImplementation implements SchedulerImpl {
     public LegacySpigotImplementation(FoliaLib foliaLib) {
         this.plugin = foliaLib.getPlugin();
         this.scheduler = plugin.getServer().getScheduler();
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull Location location) {
+        return this.plugin.getServer().isPrimaryThread();
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull Location location, int squareRadiusChunks) {
+        return this.plugin.getServer().isPrimaryThread();
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull Block block) {
+        return this.plugin.getServer().isPrimaryThread();
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ) {
+        return this.plugin.getServer().isPrimaryThread();
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ, int squareRadiusChunks) {
+        return this.plugin.getServer().isPrimaryThread();
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull Entity entity) {
+        return this.plugin.getServer().isPrimaryThread();
+    }
+
+    @Override
+    public boolean isGlobalTickThread() {
+        return this.plugin.getServer().isPrimaryThread();
     }
 
     @Override

--- a/platform/spigot/src/main/java/com/tcoded/folialib/impl/SpigotImplementation.java
+++ b/platform/spigot/src/main/java/com/tcoded/folialib/impl/SpigotImplementation.java
@@ -6,6 +6,8 @@ import com.tcoded.folialib.util.TimeConverter;
 import com.tcoded.folialib.wrapper.task.WrappedTask;
 import com.tcoded.folialib.wrapper.task.WrappedBukkitTask;
 import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -32,6 +34,41 @@ public class SpigotImplementation implements SchedulerImpl {
     public SpigotImplementation(FoliaLib foliaLib) {
         this.plugin = foliaLib.getPlugin();
         this.scheduler = plugin.getServer().getScheduler();
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull Location location) {
+        return this.plugin.getServer().isPrimaryThread();
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull Location location, int squareRadiusChunks) {
+        return this.plugin.getServer().isPrimaryThread();
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull Block block) {
+        return this.plugin.getServer().isPrimaryThread();
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ) {
+        return this.plugin.getServer().isPrimaryThread();
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull World world, int chunkX, int chunkZ, int squareRadiusChunks) {
+        return this.plugin.getServer().isPrimaryThread();
+    }
+
+    @Override
+    public boolean isOwnedByCurrentRegion(@NotNull Entity entity) {
+        return this.plugin.getServer().isPrimaryThread();
+    }
+
+    @Override
+    public boolean isGlobalTickThread() {
+        return this.plugin.getServer().isPrimaryThread();
     }
 
     @Override


### PR DESCRIPTION
Being able to check if your thread is allowed to mess with a region is super important, and I feel it fits in this library. Javadocs were taken directly from the [Folia javadocs](https://jd.papermc.io/folia/1.20/org/bukkit/Bukkit.html).

The method implementation only matters for Folia, otherwise, all methods return `Bukkit.isPrimaryThread()`