### PR TITLE
Implement teleportAsync with TeleportCause

### DIFF
--- a/common/src/main/java/com/tcoded/folialib/enums/ImplementationType.java
+++ b/common/src/main/java/com/tcoded/folialib/enums/ImplementationType.java
@@ -26,7 +26,7 @@ public enum ImplementationType {
     ),
     PAPER (
             "PaperImplementation",
-            new Supplier[] {ImplementationTestsUtil::isTaskConsumersSupported},
+            new Supplier[] {ImplementationTestsUtil::isTaskConsumersSupported, ImplementationTestsUtil::isAsyncTeleportSupported},
             "com.destroystokyo.paper.PaperConfig", "io.papermc.paper.configuration.Configuration"
     ),
     LEGACY_PAPER (

--- a/common/src/main/java/com/tcoded/folialib/util/ImplementationTestsUtil.java
+++ b/common/src/main/java/com/tcoded/folialib/util/ImplementationTestsUtil.java
@@ -1,5 +1,8 @@
 package com.tcoded.folialib.util;
 
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
@@ -8,34 +11,34 @@ import java.util.function.Consumer;
 
 public class ImplementationTestsUtil {
 
-    private static final boolean IS_CANCELLED_SUPPORTED;
-    private static final boolean IS_TASK_CONSUMERS_SUPPORTED;
-
+    private static boolean IS_CANCELLED_SUPPORTED;
+    private static boolean IS_TASK_CONSUMERS_SUPPORTED;
+    private static boolean IS_ASYNC_TELEPORT_SUPPORTED;
 
     static {
-        boolean isCancelledSupported = false;
         try {
-            Class<BukkitTask> bukkitTaskClass = BukkitTask.class;
             // noinspection JavaReflectionMemberAccess
-            bukkitTaskClass.getDeclaredMethod("isCancelled");
-            isCancelledSupported = true;
+            BukkitTask.class.getDeclaredMethod("isCancelled");
+            IS_CANCELLED_SUPPORTED = true;
         } catch (NoSuchMethodException e) {
-            // ignore
+            IS_CANCELLED_SUPPORTED = false;
         }
-        // Set class-wide
-        IS_CANCELLED_SUPPORTED = isCancelledSupported;
 
-        boolean taskConsumersSupported = false;
         try {
-            Class<BukkitScheduler> bukkitSchedulerClass = BukkitScheduler.class;
             // noinspection JavaReflectionMemberAccess
-            bukkitSchedulerClass.getDeclaredMethod("runTask", Plugin.class, Consumer.class);
-            taskConsumersSupported = true;
+            BukkitScheduler.class.getDeclaredMethod("runTask", Plugin.class, Consumer.class);
+            IS_TASK_CONSUMERS_SUPPORTED = true;
         } catch (NoSuchMethodException e) {
-            // ignore
+            IS_TASK_CONSUMERS_SUPPORTED = false;
         }
-        // Set class-wide
-        IS_TASK_CONSUMERS_SUPPORTED = taskConsumersSupported;
+
+        try {
+            // noinspection JavaReflectionMemberAccess
+            Entity.class.getDeclaredMethod("teleportAsync", Location.class, PlayerTeleportEvent.TeleportCause.class);
+            IS_ASYNC_TELEPORT_SUPPORTED = true;
+        } catch (NoSuchMethodException e) {
+            IS_ASYNC_TELEPORT_SUPPORTED = false;
+        }
     }
 
     public static boolean isCancelledSupported() {
@@ -46,4 +49,7 @@ public class ImplementationTestsUtil {
         return IS_TASK_CONSUMERS_SUPPORTED;
     }
 
+    public static boolean isAsyncTeleportSupported() {
+        return IS_ASYNC_TELEPORT_SUPPORTED;
+    }
 }

--- a/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
+++ b/platform/common/src/main/java/com/tcoded/folialib/impl/ServerImplementation.java
@@ -5,6 +5,7 @@ import com.tcoded.folialib.wrapper.task.WrappedTask;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -526,10 +527,23 @@ public interface ServerImplementation {
     Player getPlayer(UUID uuid);
 
     /**
-     * Teleport a player to a location async
-     * @return Future when the teleport is completed or failed
+     * Loads/Generates(in Paper/Folia 1.13+) the Chunk asynchronously, and then teleports the entity when the chunk is ready.
+     * @param entity Entity to teleport
+     * @param location Location to teleport to
+     * @return A future that will be completed with the result of the teleport
      */
-    CompletableFuture<Boolean> teleportAsync(Player player, Location location);
+    default CompletableFuture<Boolean> teleportAsync(Entity entity, Location location) {
+        return teleportAsync(entity, location, PlayerTeleportEvent.TeleportCause.PLUGIN);
+    }
+
+    /**
+     * Loads/Generates(in Paper/Folia 1.13+) the Chunk asynchronously, and then teleports the entity when the chunk is ready.
+     * @param entity Entity to teleport
+     * @param location Location to teleport to
+     * @param cause Reason for teleport
+     * @return A future that will be completed with the result of the teleport
+     */
+    CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause);
 
     /**
      * Wraps a native task (Folia or Bukkit) into a WrappedTask

--- a/platform/folia/src/main/java/com/tcoded/folialib/impl/FoliaImplementation.java
+++ b/platform/folia/src/main/java/com/tcoded/folialib/impl/FoliaImplementation.java
@@ -13,6 +13,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
@@ -473,9 +474,9 @@ public class FoliaImplementation implements ServerImplementation {
         return this.plugin.getServer().getPlayer(uuid);
     }
 
-	@Override
-    public CompletableFuture<Boolean> teleportAsync(Player player, Location location) {
-        return player.teleportAsync(location);
+    @Override
+    public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause) {
+        return entity.teleportAsync(location, cause);
     }
 
 	@Override

--- a/platform/legacy-spigot/src/main/java/com/tcoded/folialib/impl/LegacySpigotImplementation.java
+++ b/platform/legacy-spigot/src/main/java/com/tcoded/folialib/impl/LegacySpigotImplementation.java
@@ -9,7 +9,9 @@ import com.tcoded.folialib.wrapper.task.WrappedTask;
 import com.tcoded.folialib.wrapper.task.WrappedLegacyBukkitTask;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
@@ -366,16 +368,24 @@ public class LegacySpigotImplementation implements ServerImplementation {
     }
 
     @Override
-    public CompletableFuture<Boolean> teleportAsync(Player player, Location location) {
+    public CompletableFuture<Boolean> teleportAsync(Entity entity, Location location, PlayerTeleportEvent.TeleportCause cause) {
         CompletableFuture<Boolean> future = new CompletableFuture<>();
 
-        this.runAtEntity(player, (task) -> {
-            if (player.isValid() && player.isOnline()) {
-                player.teleport(location);
-                future.complete(true);
-            } else {
+        this.runAtEntity(entity, tp -> {
+            if (!entity.isValid()) { // Entity died or despawned
                 future.complete(false);
+                return;
             }
+
+            if (entity.getType() == EntityType.PLAYER) {
+                Player player = (Player) entity;
+                if (!player.isOnline()) {
+                    future.complete(false);
+                    return;
+                }
+            }
+
+            future.complete(entity.teleport(location, cause));
         });
 
         return future;

--- a/platform/paper/build.gradle
+++ b/platform/paper/build.gradle
@@ -1,9 +1,9 @@
 group = 'com.tcoded.folialib.platform'
 
 dependencies {
-    compileOnly("com.destroystokyo.paper:paper-api:1.9.4-R0.1-SNAPSHOT")
+    compileOnly("com.destroystokyo.paper:paper-api:1.20-R0.1-SNAPSHOT")
 
     implementation(project(":common"))
     implementation(project(":platform:common"))
-    implementation implementation(project(':platform:spigot',))
+    implementation implementation(project(':platform:folia',))
 }

--- a/platform/paper/src/main/java/com/tcoded/folialib/impl/PaperImplementation.java
+++ b/platform/paper/src/main/java/com/tcoded/folialib/impl/PaperImplementation.java
@@ -3,11 +3,12 @@ package com.tcoded.folialib.impl;
 import com.tcoded.folialib.FoliaLib;
 
 @SuppressWarnings("unused")
-public class PaperImplementation extends SpigotImplementation {
+public class PaperImplementation extends FoliaImplementation {
 
     public PaperImplementation(FoliaLib foliaLib) {
         super(foliaLib);
     }
 
-    // Don't need to override anything, since we're extending BukkitImplementation
+    // Don't need to override anything, since we're extending FoliaImplementation
+    // and all methods are the same as in folia starting from paper 1.20
 }


### PR DESCRIPTION
- teleportAsync can now be used with passing teleportCause
- PaperImplementation now tests for the existence of Entity#teleportAsync so we can properly use it on Paper as well
- PaperImplementation now extends FoliaImplementation since Folia's scheduler have been included in regular Paper starting from 1.20 and any other case can fall back to LegacyPaperImplementation