### PR TITLE
Add support for Folia 1.21.8 with Java 21 and Moonrise integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ group = "com.tcoded"
 allprojects {
     apply(plugin = "java")
 
-    version = "0.5.1"
+    version = "0.5.2-1.21.8"
 
     repositories {
         mavenCentral()

--- a/common/src/main/java/com/tcoded/folialib/enums/ImplementationType.java
+++ b/common/src/main/java/com/tcoded/folialib/enums/ImplementationType.java
@@ -22,7 +22,9 @@ public enum ImplementationType {
     FOLIA (
             "FoliaImplementation",
             new Supplier[0],
-            "io.papermc.paper.threadedregions.RegionizedServer"
+            "io.papermc.paper.threadedregions.RegionizedServer",
+            "ca.spottedleaf.moonrise.common.util.TickThread",
+            "ca.spottedleaf.moonrise.paper.PaperHooks"
     ),
     PAPER (
             "PaperImplementation",

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,8 +1,8 @@
 jdk:
-  - openjdk17
+  - openjdk21
 before_install:
-  - sdk install java 17.0.12-tem
-  - sdk use java 17.0.12-tem
+  - sdk install java 21.0.1-tem
+  - sdk use java 21.0.1-tem
 install:
   - echo "Running a custom install command"
   - ./gradlew clean build publishToMavenLocal

--- a/platform/folia/build.gradle.kts
+++ b/platform/folia/build.gradle.kts
@@ -1,12 +1,12 @@
 group = "com.tcoded.folialib.platform"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 dependencies {
-    compileOnly("dev.folia:folia-api:1.19.4-R0.1-SNAPSHOT")
+    compileOnly("dev.folia:folia-api:1.21.8-R0.1-SNAPSHOT")
 
     implementation(project(":common"))
     implementation(project(":platform:common"))


### PR DESCRIPTION
## Summary
This PR adds full support for Folia 1.21.8 servers with Java 21 compatibility and Moonrise integration detection.

## Changes Made
- **API Update**: Upgraded Folia API dependency from 1.19.4-R0.1-SNAPSHOT to 1.21.8-R0.1-SNAPSHOT
- **Java 21**: Updated build configuration from Java 17 to Java 21 (required by Folia 1.21.8)
- **Moonrise Detection**: Added Moonrise integration classes for proper Folia 1.21.8 server detection:
  - \ca.spottedleaf.moonrise.common.util.TickThread\
  - \ca.spottedleaf.moonrise.paper.PaperHooks\
- **Version**: Updated to \