### PR TITLE
Added a check for the relocation message.

### DIFF
--- a/common/src/main/java/com/tcoded/folialib/FoliaLib.java
+++ b/common/src/main/java/com/tcoded/folialib/FoliaLib.java
@@ -58,7 +58,7 @@ public class FoliaLib {
 
         // Check for valid relocation
         // Runtime replace commas to avoid compiler relocations changing this string too
-        // Not beautiful, but functional}
+        // Not beautiful, but functional
 
         String originalLocation = "com,tcoded,folialib,".replace(",", ".");
         // Below it will check if the library was loaded by Paper's MavenLibraryResolver.

--- a/common/src/main/java/com/tcoded/folialib/FoliaLib.java
+++ b/common/src/main/java/com/tcoded/folialib/FoliaLib.java
@@ -59,8 +59,9 @@ public class FoliaLib {
         // Check for valid relocation
         // Runtime replace commas to avoid compiler relocations changing this string too
         // Not beautiful, but functional
-
         String originalLocation = "com,tcoded,folialib,".replace(",", ".");
+        boolean isNotRelocated = this.getClass().getName().startsWith(originalLocation);
+
         // Below it will check if the library was loaded by Paper's MavenLibraryResolver.
         String path = null;
         try {
@@ -68,7 +69,8 @@ public class FoliaLib {
             if (loc != null) path = loc.toURI().getPath();
         } catch (URISyntaxException ignored) {}
         boolean isResolvedByPaper = path != null && path.contains("/libraries/") && this.isPaper();
-        if (this.getClass().getName().startsWith(originalLocation) && !isResolvedByPaper) {
+
+        if (isNotRelocated && !isResolvedByPaper) {
             Logger logger = this.plugin.getLogger();
             logger.severe("****************************************************************");
             logger.severe("FoliaLib is not relocated correctly! This will cause conflicts");

--- a/common/src/main/java/com/tcoded/folialib/FoliaLib.java
+++ b/common/src/main/java/com/tcoded/folialib/FoliaLib.java
@@ -67,7 +67,7 @@ public class FoliaLib {
             URL loc = this.getClass().getProtectionDomain().getCodeSource().getLocation();
             if (loc != null) path = loc.toURI().getPath();
         } catch (URISyntaxException ignored) {}
-        boolean isResolvedByPaper = path != null && path.contains("/libraries/");
+        boolean isResolvedByPaper = path != null && path.contains("/libraries/") && this.isPaper();
         if (this.getClass().getName().startsWith(originalLocation) && !isResolvedByPaper) {
             Logger logger = this.plugin.getLogger();
             logger.severe("****************************************************************");

--- a/common/src/main/java/com/tcoded/folialib/FoliaLib.java
+++ b/common/src/main/java/com/tcoded/folialib/FoliaLib.java
@@ -7,6 +7,8 @@ import com.tcoded.folialib.util.InvalidTickDelayNotifier;
 import org.bukkit.plugin.Plugin;
 
 import java.lang.reflect.InvocationTargetException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.logging.Logger;
 
 public class FoliaLib {
@@ -56,9 +58,17 @@ public class FoliaLib {
 
         // Check for valid relocation
         // Runtime replace commas to avoid compiler relocations changing this string too
-        // Not beautiful, but functional
+        // Not beautiful, but functional}
+
         String originalLocation = "com,tcoded,folialib,".replace(",", ".");
-        if (this.getClass().getName().startsWith(originalLocation)) {
+        // Below it will check if the library was loaded by Paper's MavenLibraryResolver.
+        String path = null;
+        try {
+            URL loc = this.getClass().getProtectionDomain().getCodeSource().getLocation();
+            if (loc != null) path = loc.toURI().getPath();
+        } catch (URISyntaxException ignored) {}
+        boolean isResolvedByPaper = path != null && path.contains("/libraries/");
+        if (this.getClass().getName().startsWith(originalLocation) && !isResolvedByPaper) {
             Logger logger = this.plugin.getLogger();
             logger.severe("****************************************************************");
             logger.severe("FoliaLib is not relocated correctly! This will cause conflicts");


### PR DESCRIPTION
This adds a check that looks if the library was downloaded by Paper's MavenLibraryResolver. If it was, it will not send the relocation message.